### PR TITLE
feat(playfield): monde Cannon-es avec bodies statiques (etape 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ dmd/dist/
 /docs/plan-implementation-mvp.md
 /.gitignore
 /CLAUDE.md
+/docs/onboarding.md
+/docs/actual-issue.md

--- a/playfield/src/main.js
+++ b/playfield/src/main.js
@@ -1,6 +1,6 @@
 /**
- * Playfield — Scene Three.js (etape 4 du plan MVP)
- * Plateau, murs, drain. Pas de physique ni de Socket.io.
+ * Playfield — Scene Three.js + monde Cannon-es (etapes 4 et 5 du plan MVP).
+ * Plateau, murs, drain cote rendu + leurs contreparties physiques statiques.
  */
 import * as THREE from "three";
 import {
@@ -11,10 +11,22 @@ import {
   WALL_THICKNESS,
   DRAIN_OPENING_WIDTH,
 } from "./constants.js";
+import {
+  createPhysicsWorld,
+  createStaticBoxBody,
+  syncMeshesWithBodies,
+  FIXED_TIME_STEP,
+  MAX_SUB_STEPS,
+} from "./physics.js";
 
 // ── Scene ──────────────────────────────────────────────
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x1a1a2e);
+
+// ── Monde physique ─────────────────────────────────────
+const world = createPhysicsWorld();
+// Couples (mesh, body) a synchroniser a chaque frame.
+const syncPairs = [];
 
 // ── Camera (vue top-down pour ecran vertical 9:16) ────
 const camera = new THREE.PerspectiveCamera(
@@ -56,11 +68,28 @@ const table = new THREE.Mesh(
 table.position.y = -TABLE_THICKNESS / 2;
 scene.add(table);
 
+const tableBody = createStaticBoxBody(world, {
+  width: TABLE_WIDTH,
+  height: TABLE_THICKNESS,
+  depth: TABLE_DEPTH,
+  position: table.position,
+});
+syncPairs.push({ mesh: table, body: tableBody });
+
 // ── Murs ───────────────────────────────────────────────
 function createWall(w, h, d, x, y, z) {
   const mesh = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), wallMat);
   mesh.position.set(x, y, z);
   scene.add(mesh);
+
+  const body = createStaticBoxBody(world, {
+    width: w,
+    height: h,
+    depth: d,
+    position: { x, y, z },
+  });
+  syncPairs.push({ mesh, body });
+
   return mesh;
 }
 
@@ -115,9 +144,19 @@ window.addEventListener("resize", () => {
   renderer.setSize(window.innerWidth, window.innerHeight);
 });
 
-// ── Boucle de rendu ────────────────────────────────────
+// ── Boucle de rendu + physique ─────────────────────────
+let lastTime = performance.now();
 function animate() {
   requestAnimationFrame(animate);
+
+  const now = performance.now();
+  // Clamp pour eviter un gros step apres un onglet en arriere-plan.
+  const delta = Math.min((now - lastTime) / 1000, 0.1);
+  lastTime = now;
+
+  world.step(FIXED_TIME_STEP, delta, MAX_SUB_STEPS);
+  syncMeshesWithBodies(syncPairs);
+
   renderer.render(scene, camera);
 }
 

--- a/playfield/src/physics.js
+++ b/playfield/src/physics.js
@@ -1,0 +1,63 @@
+/**
+ * Playfield — Monde Cannon-es (etape 5 du plan MVP).
+ *
+ * Cree le monde physique, des helpers pour les corps statiques,
+ * et expose la synchronisation mesh/body pour la boucle de rendu.
+ *
+ * Convention d'axes (cf. constants.js) :
+ *   X = gauche / droite, Y = hauteur (gravite), Z = longueur du plateau.
+ *
+ * Le plateau reste a plat dans Three.js. L'inclinaison (~6°) est simulee
+ * en ajoutant une composante Z a la gravite (vers Z+ = vers le drain).
+ */
+import * as CANNON from "cannon-es";
+
+const TILT_DEG = 6;
+const GRAVITY = 9.82;
+
+export const FIXED_TIME_STEP = 1 / 60;
+export const MAX_SUB_STEPS = 3;
+
+/**
+ * Cree le monde physique avec la gravite inclinee.
+ */
+export function createPhysicsWorld() {
+  const world = new CANNON.World();
+  const tilt = (TILT_DEG * Math.PI) / 180;
+  world.gravity.set(
+    0,
+    -GRAVITY * Math.cos(tilt),
+    GRAVITY * Math.sin(tilt),
+  );
+  world.broadphase = new CANNON.NaiveBroadphase();
+  world.solver.iterations = 10;
+  return world;
+}
+
+/**
+ * Cree un corps statique (masse 0) de forme Box et l'ajoute au monde.
+ * `width`, `height`, `depth` sont les dimensions completes de la boite
+ * (pas les half-extents). `position` est un objet { x, y, z } (compatible
+ * avec THREE.Vector3).
+ */
+export function createStaticBoxBody(world, { width, height, depth, position }) {
+  const halfExtents = new CANNON.Vec3(width / 2, height / 2, depth / 2);
+  const shape = new CANNON.Box(halfExtents);
+  const body = new CANNON.Body({ mass: 0, shape });
+  body.position.set(position.x, position.y, position.z);
+  world.addBody(body);
+  return body;
+}
+
+/**
+ * Synchronise chaque mesh Three.js avec son body Cannon-es.
+ * Inutile pour les bodies statiques, mais appele pour tous afin de
+ * supporter les bodies dynamiques ajoutes dans les etapes suivantes
+ * (bille, battes...).
+ */
+export function syncMeshesWithBodies(pairs) {
+  for (const { mesh, body } of pairs) {
+    mesh.position.copy(body.position);
+    mesh.quaternion.copy(body.quaternion);
+  }
+}


### PR DESCRIPTION
- Ajoute playfield/src/physics.js : createPhysicsWorld, createStaticBoxBody, syncMeshesWithBodies, FIXED_TIME_STEP / MAX_SUB_STEPS
- Gravite inclinee (~6°) via une composante Z pour simuler le plan incline sans incliner les meshes Three.js
- Cree les Box statiques pour le plateau et les 5 murs, suivis dans une liste syncPairs prete a accueillir les bodies dynamiques de l'etape 6
- Step du monde et sync des meshes dans la boucle de rendu avec un delta clampe