### PR TITLE
Intègre le playfield dans une boucle MVP jouable de bout en bout avec le serveur Socket.io (start, launch, collisions, ball_lost, game_over, restart).

### DIFF
--- a/docs/MVP_INTEGRATION_TEST.md
+++ b/docs/MVP_INTEGRATION_TEST.md
@@ -4,7 +4,13 @@ Ce document valide le flux complet serveur + playfield + backglass + DMD.
 
 ## 1) Lancement des 4 applications
 
-Depuis la racine du repo, ouvrir 4 terminaux :
+Depuis la racine du repo, commande unique :
+
+```bash
+npm run dev:all
+```
+
+Alternative (si besoin de logs separes), ouvrir 4 terminaux :
 
 ```bash
 cd server && npm run dev

--- a/docs/MVP_INTEGRATION_TEST.md
+++ b/docs/MVP_INTEGRATION_TEST.md
@@ -1,0 +1,66 @@
+# Integration MVP - Procedure de test
+
+Ce document valide le flux complet serveur + playfield + backglass + DMD.
+
+## 1) Lancement des 4 applications
+
+Depuis la racine du repo, ouvrir 4 terminaux :
+
+```bash
+cd server && npm run dev
+```
+
+```bash
+cd playfield && npm run dev
+```
+
+```bash
+cd backglass && npm run dev
+```
+
+```bash
+cd dmd && npm run dev
+```
+
+URLs attendues :
+
+- Playfield: `http://localhost:5173`
+- Backglass: `http://localhost:5174`
+- DMD: `http://localhost:5175`
+
+## 2) Scenario manuel de reference
+
+1. Ouvrir les 3 ecrans (playfield/backglass/dmd) dans le navigateur.
+2. Dans le playfield, cliquer une fois pour donner le focus clavier.
+3. Appuyer sur `Enter`.
+   - Attendu serveur: reception `start_game`, puis `state_updated(status=playing)`.
+   - Attendu DMD: message `BALL 1`.
+   - Attendu backglass: `status=playing`, `score=0`, `ballsLeft=3`.
+4. Appuyer sur `Space`.
+   - Attendu serveur: reception `launch_ball` + `state_updated(lastEvent=launch_ball)`.
+   - Attendu playfield: la bille est lancee depuis la zone plunger.
+5. Jouer avec `ArrowLeft` et `ArrowRight`.
+   - Attendu serveur: events flippers relays.
+   - Attendu collisions bumpers/murs/flippers: emission `collision { type }`.
+   - Attendu score: incremente sur `collision:bumper` (+100 en MVP), visible sur backglass et DMD.
+6. Laisser la bille tomber dans le drain.
+   - Attendu serveur: `ball_lost`, `ballsLeft` decremente.
+   - Attendu DMD: `BALL 2`, puis `BALL 3` apres nouvelle perte.
+   - Attendu playfield: respawn de bille pour la balle suivante.
+7. A la 3e perte de bille.
+   - Attendu serveur: `state_updated(status=game_over)` + `game_over`.
+   - Attendu DMD: `GAME OVER`.
+   - Attendu backglass: `status=game_over`, `ballsLeft=0`.
+8. Restart.
+   - Appuyer de nouveau sur `Enter`.
+   - Attendu: retour `status=playing`, score reset, message `BALL 1`.
+
+## 3) Checklist DoD integration
+
+- [ ] Une procedure unique permet de lancer les 4 apps.
+- [ ] `Enter` declenche bien `start_game` + synchro 3 ecrans.
+- [ ] `Space` declenche `launch_ball` avec lancement coherent.
+- [ ] Collisions bumpers/flippers/murs emettent des evenements sans spam excessif.
+- [ ] Drain emet `ball_lost` une fois par perte + respawn correct.
+- [ ] 3 pertes conduisent a `game_over` coherent sur les 3 ecrans.
+- [ ] Restart possible sans redemarrer les apps.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "playfield": "npm run dev --prefix playfield",
     "backglass": "npm run dev --prefix backglass",
     "dmd": "npm run dev --prefix dmd",
-    "dev:all": "concurrently \"npm run server\" \"npm run playfield\" \"npm run backglass\" \"npm run dmd\""
+    "dev:all": "concurrently \"npm run server:dev\" \"npm run playfield\" \"npm run backglass\" \"npm run dmd\""
   },
   "devDependencies": {
     "concurrently": "^8.2.2"

--- a/playfield/src/ball.js
+++ b/playfield/src/ball.js
@@ -34,8 +34,8 @@ export function createBall(scene, world) {
 
   world.addContactMaterial(
     new CANNON.ContactMaterial(MATERIALS.ball, MATERIALS.static, {
-      friction: 0.22,
-      restitution: 0.35,
+      friction: 0.28,
+      restitution: 0.04,
     }),
   );
   world.addContactMaterial(

--- a/playfield/src/ball.js
+++ b/playfield/src/ball.js
@@ -1,40 +1,23 @@
-/**
- * Playfield — Bille (etape 6 du plan MVP).
- *
- * Mesh Three.js (sphere metallique) + body Cannon-es (Sphere, masse 1),
- * proprietes de contact (restitution 0.5, friction 0.3) et resetBall()
- * qui place la bille au spawn plunger defini dans constants.js.
- */
 import * as THREE from "three";
 import * as CANNON from "cannon-es";
 import {
+  BALL_RADIUS,
+  BALL_MASS,
+  BALL_LINEAR_DAMPING,
+  BALL_ANGULAR_DAMPING,
   PLUNGER_SPAWN_X,
   PLUNGER_SPAWN_Y,
   PLUNGER_SPAWN_Z,
-  PLUNGER_IMPULSE_FORCE,
 } from "./constants.js";
 import { MATERIALS } from "./physics.js";
 
-export const BALL_RADIUS = 0.25;
-export const BALL_MASS = 1;
-export const BALL_RESTITUTION = 0.5;
-export const BALL_FRICTION = 0.3;
-// Hauteur fixe : centre de la bille juste au-dessus du plateau (y=0).
-const BALL_FIXED_Y = BALL_RADIUS + 0.01;
-
 /**
- * Cree le mesh + body de la bille, ajoute le ContactMaterial ball<->static
- * au monde, et positionne la bille au spawn plunger.
- * Retourne le couple { mesh, body } a pousser dans syncPairs.
+ * Cree la bille (mesh + body) et retourne des helpers de gameplay.
  */
 export function createBall(scene, world) {
   const mesh = new THREE.Mesh(
-    new THREE.SphereGeometry(BALL_RADIUS, 32, 32),
-    new THREE.MeshStandardMaterial({
-      color: 0xcccccc,
-      metalness: 0.9,
-      roughness: 0.2,
-    }),
+    new THREE.SphereGeometry(BALL_RADIUS, 24, 24),
+    new THREE.MeshStandardMaterial({ color: 0xf2f2f2, metalness: 0.6, roughness: 0.2 }),
   );
   scene.add(mesh);
 
@@ -42,58 +25,33 @@ export function createBall(scene, world) {
     mass: BALL_MASS,
     shape: new CANNON.Sphere(BALL_RADIUS),
     material: MATERIALS.ball,
+    linearDamping: BALL_LINEAR_DAMPING,
+    angularDamping: BALL_ANGULAR_DAMPING,
   });
+  body.position.set(PLUNGER_SPAWN_X, PLUNGER_SPAWN_Y, PLUNGER_SPAWN_Z);
   body.userData = { type: "ball" };
   world.addBody(body);
 
-  // Contact bille <-> surfaces statiques (plateau, murs).
   world.addContactMaterial(
     new CANNON.ContactMaterial(MATERIALS.ball, MATERIALS.static, {
-      friction: BALL_FRICTION,
-      restitution: BALL_RESTITUTION,
+      friction: 0.22,
+      restitution: 0.35,
+    }),
+  );
+  world.addContactMaterial(
+    new CANNON.ContactMaterial(MATERIALS.ball, MATERIALS.table, {
+      friction: 0.28,
+      restitution: 0.05,
     }),
   );
 
-  const ball = { mesh, body };
-  resetBall(ball);
-  return ball;
-}
+  function resetBall() {
+    body.velocity.set(0, 0, 0);
+    body.angularVelocity.set(0, 0, 0);
+    body.position.set(PLUNGER_SPAWN_X, PLUNGER_SPAWN_Y, PLUNGER_SPAWN_Z);
+    body.quaternion.set(0, 0, 0, 1);
+    body.wakeUp();
+  }
 
-/**
- * Verrouille la bille sur le plan du plateau (Y fixe).
- * Appeler chaque frame APRES world.step().
- */
-export function clampBall({ body }) {
-  // Verrouiller la bille sur le plan du plateau — pas de physique Y.
-  body.position.y = BALL_FIXED_Y;
-  body.velocity.y = 0;
-}
-
-// Flag anti double-lancement : true apres un lancement, false apres resetBall.
-let launched = false;
-
-/**
- * Replace la bille au spawn plunger et remet ses vitesses a zero.
- * Reutilisable par l'etape 7 (plunger) et l'etape 10 (perte de bille).
- */
-export function resetBall({ body }) {
-  body.position.set(PLUNGER_SPAWN_X, PLUNGER_SPAWN_Y, PLUNGER_SPAWN_Z);
-  body.velocity.set(0, 0, 0);
-  body.angularVelocity.set(0, 0, 0);
-  body.quaternion.set(0, 0, 0, 1);
-  body.wakeUp();
-  launched = false;
-}
-
-/**
- * Lance la bille depuis le spawn plunger.
- * Applique une impulsion en Z negatif (vers le haut du plateau).
- * Refuse le lancement si la bille a deja ete lancee (anti double-lancement).
- * Retourne true si le lancement a eu lieu, false sinon.
- */
-export function launchBall({ body }) {
-  if (launched) return false;
-  body.applyImpulse(new CANNON.Vec3(0, 0, -PLUNGER_IMPULSE_FORCE));
-  launched = true;
-  return true;
+  return { mesh, body, resetBall };
 }

--- a/playfield/src/bumpers.js
+++ b/playfield/src/bumpers.js
@@ -16,7 +16,7 @@ import { MATERIALS } from "./physics.js";
 
 const BUMPER_COLOR = 0xff2266;
 const BALL_BUMPER_FRICTION = 0.1;
-const BALL_BUMPER_RESTITUTION = 0.8;
+const BALL_BUMPER_RESTITUTION = 0.35;
 
 /**
  * Cree tous les bumpers (mesh + body statique) et ajoute le

--- a/playfield/src/collisions.js
+++ b/playfield/src/collisions.js
@@ -1,98 +1,48 @@
-/**
- * Playfield — Collisions & drain (etape 10 du plan MVP).
- *
- * Detecte la perte de bille (zone drain) et les collisions typees
- * (bumper, wall, flipper) via les evenements Cannon-es.
- * Emet ball_lost et collision vers le serveur avec debounce par type.
- */
 import {
-  DRAIN_Z_THRESHOLD,
-  BUMPER_REPULSE_FORCE,
+  DRAIN_MIN_Z,
+  DRAIN_MAX_Z,
+  DRAIN_MIN_X,
+  DRAIN_MAX_X,
+  DRAIN_MAX_Y,
   COLLISION_COOLDOWN_MS,
 } from "./constants.js";
-import { emitBallLost, emitCollision } from "./network.js";
-import * as CANNON from "cannon-es";
-
-// Dernier timestamp d'emission par type de collision.
-const lastEmitByType = {};
-
-// Flag pour ne pas emettre ball_lost plusieurs fois par perte.
-let ballLostEmitted = false;
 
 /**
- * Verifie si le cooldown est passe pour un type donne.
+ * Branche la detection de collision de la bille et emet `collision` au serveur.
  */
-function canEmit(type) {
-  const now = performance.now();
-  if (lastEmitByType[type] && now - lastEmitByType[type] < COLLISION_COOLDOWN_MS) {
-    return false;
-  }
-  lastEmitByType[type] = now;
-  return true;
-}
+export function attachCollisionEmitter(ballBody, emitCollision) {
+  const lastByKey = new Map();
 
-/**
- * Enregistre les listeners de collision sur le body de la bille.
- * `socket` : instance socket.io pour emettre les evenements.
- * `ballBody` : le body Cannon-es de la bille.
- */
-export function setupCollisionListeners(socket, ballBody) {
   ballBody.addEventListener("collide", (event) => {
-    const type = event.body.userData?.type;
-    if (!type || type === "ball" || type === "table") return;
+    const type = event.body?.userData?.type;
+    if (!type || !["bumper", "wall", "flipper", "drain"].includes(type)) return;
 
-    console.log("[collision] bille →", type);
+    const key = `${type}:${event.body.id}`;
+    const now = performance.now();
+    const prev = lastByKey.get(key);
+    if (prev != null && now - prev < COLLISION_COOLDOWN_MS) return;
+    lastByKey.set(key, now);
 
-    if (canEmit(type)) {
-      emitCollision(socket, type);
-    }
-
-    // Impulsion de repousse pour les bumpers.
-    if (type === "bumper") {
-      const contact = event.contact;
-      const normal = new CANNON.Vec3();
-      // La normale pointe de B vers A ; s'assurer qu'elle repousse la bille.
-      if (contact.bi === ballBody) {
-        contact.ni.negate(normal);
-      } else {
-        normal.copy(contact.ni);
-      }
-      normal.y = 0; // Repousse uniquement sur le plan du plateau.
-      normal.normalize();
-      normal.scale(BUMPER_REPULSE_FORCE, normal);
-      ballBody.applyImpulse(normal);
-    }
+    emitCollision(type);
   });
 }
 
 /**
- * Verifie a chaque frame si la bille est dans la zone drain.
- * Appeler dans la boucle de rendu APRES world.step().
- * Retourne true si la bille vient d'etre perdue (pour declencher resetBall).
+ * Drain logique : une perte de bille max jusqu'au prochain reset.
  */
-export function checkDrain(socket, ballBody, gameStatus) {
-  if (gameStatus !== "playing") {
-    ballLostEmitted = false;
-    return false;
-  }
-
-  if (ballBody.position.z > DRAIN_Z_THRESHOLD) {
-    if (!ballLostEmitted) {
-      ballLostEmitted = true;
-      emitBallLost(socket);
-      return true;
-    }
-  } else {
-    // Bille revenue sur le plateau (apres reset) → re-armer le flag.
-    ballLostEmitted = false;
-  }
-
-  return false;
+export function createDrainWatcher() {
+  return {
+    canLoseBall: true,
+  };
 }
 
-/**
- * Re-arme le flag ball_lost (a appeler apres resetBall).
- */
-export function resetDrainFlag() {
-  ballLostEmitted = false;
+export function detectDrain(ballBody, drainState) {
+  if (!drainState.canLoseBall) return false;
+  const p = ballBody.position;
+  const insideX = p.x >= DRAIN_MIN_X && p.x <= DRAIN_MAX_X;
+  const insideZ = p.z >= DRAIN_MIN_Z && p.z <= DRAIN_MAX_Z;
+  const belowY = p.y <= DRAIN_MAX_Y;
+  if (!(insideX && insideZ && belowY)) return false;
+  drainState.canLoseBall = false;
+  return true;
 }

--- a/playfield/src/constants.js
+++ b/playfield/src/constants.js
@@ -28,10 +28,10 @@ export const PLUNGER_SPAWN_Z = TABLE_DEPTH / 2 - 1;
 // Bille
 export const BALL_RADIUS = 0.17;
 export const BALL_MASS = 0.1;
-export const BALL_LINEAR_DAMPING = 0.015;
+export const BALL_LINEAR_DAMPING = 0.007;
 export const BALL_ANGULAR_DAMPING = 0.02;
 export const LAUNCH_IMPULSE_Z = -9.5;
-export const LAUNCH_MAX_SPEED = 12;
+export const LAUNCH_MAX_SPEED = 18;
 
 // Drain / perte de bille (zone de detection dans l'ouverture)
 export const DRAIN_MIN_Z = TABLE_DEPTH / 2 - 0.4;
@@ -41,11 +41,11 @@ export const DRAIN_MAX_X = DRAIN_OPENING_WIDTH / 2 + 0.15;
 export const DRAIN_MAX_Y = 0.2;
 
 // Flippers
-export const FLIPPER_LENGTH = 1.6;
+export const FLIPPER_LENGTH = 1.45;
 export const FLIPPER_WIDTH = 0.28;
 export const FLIPPER_HEIGHT = 0.18;
 export const FLIPPER_REST_ANGLE = 0.9;
-export const FLIPPER_PIVOT_X = 1.2;
+export const FLIPPER_PIVOT_X = 1.35;
 export const FLIPPER_PIVOT_Z = TABLE_DEPTH / 2 - 1.4;
 export const FLIPPER_PIVOT_Y = FLIPPER_HEIGHT / 2;
 export const FLIPPER_SPEED = 18;

--- a/playfield/src/constants.js
+++ b/playfield/src/constants.js
@@ -4,7 +4,7 @@
  *   Y = hauteur (perpendiculaire au plateau) — axe de gravite Cannon-es (0, -9.82, 0)
  *   Z = longueur du plateau (Z negatif = haut du plateau, Z positif = bas / joueur)
  *
- * L'inclinaison (~12°) est simulee dans Cannon-es via une composante Z
+ * L'inclinaison (~6-7°) sera simulee dans Cannon-es via une composante Z
  * dans le vecteur de gravite, sans incliner les meshes Three.js.
  */
 
@@ -20,39 +20,44 @@ export const WALL_THICKNESS = 0.3;
 // Drain (ouverture entre les futurs flippers)
 export const DRAIN_OPENING_WIDTH = 2.5;
 
-// Spawn bille (centre bas du plateau, au-dessus du drain)
-export const PLUNGER_SPAWN_X = 0;
-export const PLUNGER_SPAWN_Y = 0.26;
-export const PLUNGER_SPAWN_Z = TABLE_DEPTH / 2 - 1.5;
+// Spawn bille (zone plunger, en bas a droite du plateau)
+export const PLUNGER_SPAWN_X = TABLE_WIDTH / 2 - 0.8;
+export const PLUNGER_SPAWN_Y = 0.5;
+export const PLUNGER_SPAWN_Z = TABLE_DEPTH / 2 - 1;
 
-// Plunger — force d'impulsion (Z negatif = vers le haut du plateau)
-export const PLUNGER_IMPULSE_FORCE = 18;
+// Bille
+export const BALL_RADIUS = 0.17;
+export const BALL_MASS = 0.1;
+export const BALL_LINEAR_DAMPING = 0.015;
+export const BALL_ANGULAR_DAMPING = 0.02;
+export const LAUNCH_IMPULSE_Z = -9.5;
+export const LAUNCH_MAX_SPEED = 12;
 
-// Flippers (battes)
-export const FLIPPER_LENGTH = 2.0;
-export const FLIPPER_WIDTH = 0.4;
-export const FLIPPER_HEIGHT = 0.3;
-export const FLIPPER_REST_ANGLE = 0.5;   // radians (~28°), battes au repos vers le drain
-export const FLIPPER_PIVOT_X = DRAIN_OPENING_WIDTH / 2 + 0.2; // distance du centre (±)
-export const FLIPPER_PIVOT_Z = TABLE_DEPTH / 2 - 1.5;
-export const FLIPPER_PIVOT_Y = FLIPPER_HEIGHT / 2 + 0.05;
+// Drain / perte de bille (zone de detection dans l'ouverture)
+export const DRAIN_MIN_Z = TABLE_DEPTH / 2 - 0.4;
+export const DRAIN_MAX_Z = TABLE_DEPTH / 2 + 1.2;
+export const DRAIN_MIN_X = -DRAIN_OPENING_WIDTH / 2 - 0.15;
+export const DRAIN_MAX_X = DRAIN_OPENING_WIDTH / 2 + 0.15;
+export const DRAIN_MAX_Y = 0.2;
+
+// Flippers
+export const FLIPPER_LENGTH = 1.6;
+export const FLIPPER_WIDTH = 0.28;
+export const FLIPPER_HEIGHT = 0.18;
+export const FLIPPER_REST_ANGLE = 0.9;
+export const FLIPPER_PIVOT_X = 1.2;
+export const FLIPPER_PIVOT_Z = TABLE_DEPTH / 2 - 1.4;
+export const FLIPPER_PIVOT_Y = FLIPPER_HEIGHT / 2;
+export const FLIPPER_SPEED = 18;
 
 // Bumpers
-export const BUMPER_RADIUS = 0.5;
-export const BUMPER_HEIGHT = 0.6;
-export const BUMPER_REPULSE_FORCE = 3;
+export const BUMPER_RADIUS = 0.45;
+export const BUMPER_HEIGHT = 0.28;
 export const BUMPER_POSITIONS = [
-  { x: -2, z: -2 },
-  { x: 2, z: -4 },
-  { x: 0, z: -6 },
+  { x: -2.3, z: -4.8 },
+  { x: 0, z: -6.0 },
+  { x: 2.3, z: -4.8 },
 ];
 
-// Drain — seuil Z au-dela duquel la bille est consideree perdue
-// Juste apres le mur du bas (epaisseur WALL_THICKNESS) + marge pour le rayon bille.
-export const DRAIN_Z_THRESHOLD = TABLE_DEPTH / 2 + WALL_THICKNESS + 0.3;
-
-// Flippers — vitesse de rotation (rad/s)
-export const FLIPPER_SPEED = 15;
-
-// Collisions — cooldown entre deux emissions du meme type (ms)
-export const COLLISION_COOLDOWN_MS = 300;
+// Anti-spam collisions reseau
+export const COLLISION_COOLDOWN_MS = 120;

--- a/playfield/src/flippers.js
+++ b/playfield/src/flippers.js
@@ -115,8 +115,8 @@ export function createFlippers(scene, world) {
 
   world.addContactMaterial(
     new CANNON.ContactMaterial(MATERIALS.flipper, MATERIALS.ball, {
-      friction: 0.3,
-      restitution: 0.8,
+      friction: 0.28,
+      restitution: 0.22,
     }),
   );
 

--- a/playfield/src/main.js
+++ b/playfield/src/main.js
@@ -124,15 +124,131 @@ function addStaticBoxVisual(width, height, depth, x, y, z, type = "wall", materi
   syncPairs.push({ mesh, body });
 }
 
+function addStaticAngledBoxVisual({
+  width,
+  height,
+  depth,
+  x,
+  y,
+  z,
+  angleY,
+  type = "wall",
+  material = wallMat,
+  physicsMaterial = "static",
+}) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(width, height, depth), material);
+  mesh.position.set(x, y, z);
+  mesh.rotation.y = angleY;
+  scene.add(mesh);
+
+  const body = createStaticBoxBody(world, {
+    width,
+    height,
+    depth,
+    position: { x, y, z },
+    material: physicsMaterial,
+    type,
+  });
+  const q = new CANNON.Quaternion();
+  q.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), angleY);
+  body.quaternion.copy(q);
+
+  syncPairs.push({ mesh, body });
+}
+
+
 addStaticBoxVisual(TABLE_WIDTH, TABLE_THICKNESS, TABLE_DEPTH, 0, -TABLE_THICKNESS / 2, 0, "table", tableMat, "table");
 addStaticBoxVisual(WALL_THICKNESS, WALL_HEIGHT, TABLE_DEPTH, -TABLE_WIDTH / 2 - WALL_THICKNESS / 2, WALL_HEIGHT / 2, 0);
 addStaticBoxVisual(WALL_THICKNESS, WALL_HEIGHT, TABLE_DEPTH, TABLE_WIDTH / 2 + WALL_THICKNESS / 2, WALL_HEIGHT / 2, 0);
 addStaticBoxVisual(TABLE_WIDTH + WALL_THICKNESS * 2, WALL_HEIGHT, WALL_THICKNESS, 0, WALL_HEIGHT / 2, -TABLE_DEPTH / 2 - WALL_THICKNESS / 2);
+// Retenue invisible au-dessus des murs (evite les sorties hors plateau).
+addStaticBoxVisual(TABLE_WIDTH + 0.4, 0.16, 0.16, 0, 1.02, -TABLE_DEPTH / 2 + 0.05, "wall", new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 }), "static");
+addStaticBoxVisual(TABLE_WIDTH + 0.4, 0.16, 0.16, 0, 1.02, TABLE_DEPTH / 2 - 0.05, "wall", new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 }), "static");
+addStaticBoxVisual(0.16, 0.16, TABLE_DEPTH + 0.4, -TABLE_WIDTH / 2 + 0.05, 1.02, 0, "wall", new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 }), "static");
+addStaticBoxVisual(0.16, 0.16, TABLE_DEPTH + 0.4, TABLE_WIDTH / 2 - 0.05, 1.02, 0, "wall", new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 }), "static");
+
+// Angles "arrondis" en haut (chamfreins diagonaux), comme sur le schema.
+addStaticAngledBoxVisual({
+  width: 3.0,
+  height: WALL_HEIGHT,
+  depth: WALL_THICKNESS,
+  x: -TABLE_WIDTH / 2 + 1.2,
+  y: WALL_HEIGHT / 2,
+  z: -TABLE_DEPTH / 2 + 1.05,
+  angleY: 0.52,
+});
+addStaticAngledBoxVisual({
+  width: 3.0,
+  height: WALL_HEIGHT,
+  depth: WALL_THICKNESS,
+  x: TABLE_WIDTH / 2 - 1.2,
+  y: WALL_HEIGHT / 2,
+  z: -TABLE_DEPTH / 2 + 1.05,
+  angleY: -0.52,
+});
 
 const bottomWallWidth = (TABLE_WIDTH - DRAIN_OPENING_WIDTH) / 2;
 const bottomZ = TABLE_DEPTH / 2 + WALL_THICKNESS / 2;
 addStaticBoxVisual(bottomWallWidth, WALL_HEIGHT, WALL_THICKNESS, -(DRAIN_OPENING_WIDTH / 2 + bottomWallWidth / 2), WALL_HEIGHT / 2, bottomZ);
 addStaticBoxVisual(bottomWallWidth, WALL_HEIGHT, WALL_THICKNESS, DRAIN_OPENING_WIDTH / 2 + bottomWallWidth / 2, WALL_HEIGHT / 2, bottomZ);
+
+// Tunnel droit (couloir de lancement) du haut vers le bas du playfield.
+addStaticBoxVisual(
+  WALL_THICKNESS,
+  WALL_HEIGHT,
+  11.0,
+  TABLE_WIDTH / 2 - 1.35,
+  WALL_HEIGHT / 2,
+  3.0,
+);
+// Butee basse du tunnel pour eviter le trou vers l'exterieur.
+addStaticBoxVisual(
+  1.2,
+  WALL_HEIGHT,
+  WALL_THICKNESS,
+  TABLE_WIDTH / 2 - 0.6,
+  WALL_HEIGHT / 2,
+  TABLE_DEPTH / 2 + WALL_THICKNESS / 2,
+);
+
+// Fausse vitre : couvre l'integralite du flipper (largeur + longueur).
+addStaticBoxVisual(
+  TABLE_WIDTH - 0.3,
+  0.04,
+  TABLE_DEPTH - 0.3,
+  0,
+  1.95,
+  0,
+  "glass",
+  new THREE.MeshStandardMaterial({
+    color: 0xaecbff,
+    transparent: true,
+    opacity: 0.14,
+    metalness: 0.1,
+    roughness: 0.2,
+  }),
+  "table",
+);
+
+// Guides anti-blocage au-dessus des flippers (orientation vers le bas/centre).
+addStaticAngledBoxVisual({
+  width: 4.8,
+  height: WALL_HEIGHT,
+  depth: 0.32,
+  x: -3.22,
+  y: WALL_HEIGHT / 2,
+  z: TABLE_DEPTH / 2 - 2.0,
+  angleY: -0.46,
+});
+addStaticAngledBoxVisual({
+  width: 2.25,
+  height: WALL_HEIGHT,
+  depth: 0.32,
+  x: 2.28,
+  y: WALL_HEIGHT / 2,
+  z: TABLE_DEPTH / 2 - 2.0,
+  angleY: 0.46,
+});
 
 const bumpers = createBumpers(scene, world);
 syncPairs.push(...bumpers);
@@ -160,7 +276,7 @@ function tryLaunch() {
 
   emitLaunchBall(socket);
   ball.body.wakeUp();
-  ball.body.applyImpulse(new CANNON.Vec3(0, 0.35, LAUNCH_IMPULSE_Z), ball.body.position);
+  ball.body.applyImpulse(new CANNON.Vec3(0, 0.08, LAUNCH_IMPULSE_Z), ball.body.position);
 }
 
 window.addEventListener("keydown", (event) => {
@@ -223,6 +339,20 @@ function animate() {
   const lost = detectDrain(ball.body, drainWatcher);
   if (lost && gameState.status === "playing") {
     emitCollision(socket, "drain");
+    emitBallLost(socket);
+    pendingRespawn = true;
+    ball.body.velocity.set(0, 0, 0);
+    ball.body.angularVelocity.set(0, 0, 0);
+    ball.body.position.set(0, -4, 0);
+  }
+
+  // Garde-fou: si la bille sort des limites du plateau, compter une perte de bille.
+  const outOfBounds =
+    Math.abs(ball.body.position.x) > TABLE_WIDTH * 0.75 ||
+    ball.body.position.z < -TABLE_DEPTH * 0.65 ||
+    ball.body.position.z > TABLE_DEPTH * 0.62;
+  if (outOfBounds && gameState.status === "playing" && drainWatcher.canLoseBall) {
+    drainWatcher.canLoseBall = false;
     emitBallLost(socket);
     pendingRespawn = true;
     ball.body.velocity.set(0, 0, 0);

--- a/playfield/src/main.js
+++ b/playfield/src/main.js
@@ -1,8 +1,5 @@
-/**
- * Playfield — Scene Three.js + monde Cannon-es (etapes 4 et 5 du plan MVP).
- * Plateau, murs, drain cote rendu + leurs contreparties physiques statiques.
- */
 import * as THREE from "three";
+import * as CANNON from "cannon-es";
 import {
   TABLE_WIDTH,
   TABLE_DEPTH,
@@ -10,6 +7,11 @@ import {
   WALL_HEIGHT,
   WALL_THICKNESS,
   DRAIN_OPENING_WIDTH,
+  PLUNGER_SPAWN_X,
+  PLUNGER_SPAWN_Y,
+  PLUNGER_SPAWN_Z,
+  LAUNCH_IMPULSE_Z,
+  LAUNCH_MAX_SPEED,
 } from "./constants.js";
 import {
   createPhysicsWorld,
@@ -18,35 +20,40 @@ import {
   FIXED_TIME_STEP,
   MAX_SUB_STEPS,
 } from "./physics.js";
-import { createBall, launchBall, resetBall, clampBall } from "./ball.js";
-import { initNetwork, emitStartGame, emitLaunchBall, emitFlipperLeftDown, emitFlipperLeftUp, emitFlipperRightDown, emitFlipperRightUp, gameState } from "./network.js";
-import { createFlippers, setFlipperActive, updateFlippers, postStepFlippers } from "./flippers.js";
 import { createBumpers } from "./bumpers.js";
-import { setupCollisionListeners, checkDrain, resetDrainFlag } from "./collisions.js";
+import {
+  createFlippers,
+  setFlipperActive,
+  updateFlippers,
+  postStepFlippers,
+} from "./flippers.js";
+import { createBall } from "./ball.js";
+import {
+  initNetwork,
+  gameState,
+  emitStartGame,
+  emitLaunchBall,
+  emitFlipperLeftDown,
+  emitFlipperLeftUp,
+  emitFlipperRightDown,
+  emitFlipperRightUp,
+  emitBallLost,
+  emitCollision,
+} from "./network.js";
+import {
+  attachCollisionEmitter,
+  createDrainWatcher,
+  detectDrain,
+} from "./collisions.js";
 
-// ── Scene ──────────────────────────────────────────────
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x1a1a2e);
 
-// ── Monde physique ─────────────────────────────────────
-const world = createPhysicsWorld();
-// Couples (mesh, body) a synchroniser a chaque frame.
-const syncPairs = [];
-
-// ── Camera (vue top-down pour ecran vertical 9:16) ────
-const camera = new THREE.PerspectiveCamera(
-  60,
-  window.innerWidth / window.innerHeight,
-  0.1,
-  100,
-);
-// Camera directement au-dessus du plateau, regard vers le bas
+const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 100);
 camera.position.set(0, 20, 0);
 camera.lookAt(0, 0, 0);
-// Rotation pour que Z+ (bas du plateau / joueur) = bas de l'ecran
 camera.up.set(0, 0, -1);
 
-// ── Renderer ───────────────────────────────────────────
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.setPixelRatio(window.devicePixelRatio);
@@ -54,195 +61,176 @@ document.body.style.margin = "0";
 document.body.style.overflow = "hidden";
 document.body.appendChild(renderer.domElement);
 
-// ── Lumieres ───────────────────────────────────────────
 scene.add(new THREE.AmbientLight(0xffffff, 0.6));
-
 const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
 dirLight.position.set(5, 15, 5);
 scene.add(dirLight);
 
-// ── Materiaux ──────────────────────────────────────────
+const hud = document.createElement("div");
+hud.style.position = "fixed";
+hud.style.top = "8px";
+hud.style.left = "8px";
+hud.style.padding = "8px 10px";
+hud.style.background = "rgba(0,0,0,0.45)";
+hud.style.color = "#fff";
+hud.style.fontFamily = "monospace";
+hud.style.fontSize = "12px";
+hud.style.borderRadius = "8px";
+hud.style.pointerEvents = "none";
+document.body.appendChild(hud);
+
 const tableMat = new THREE.MeshStandardMaterial({ color: 0x2d5a27 });
 const wallMat = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
 
-// ── Plateau ────────────────────────────────────────────
-const table = new THREE.Mesh(
-  new THREE.BoxGeometry(TABLE_WIDTH, TABLE_THICKNESS, TABLE_DEPTH),
-  tableMat,
-);
-table.position.y = -TABLE_THICKNESS / 2;
-scene.add(table);
+const world = createPhysicsWorld();
+const syncPairs = [];
+const drainWatcher = createDrainWatcher();
+let pendingRespawn = false;
+let ball = null;
 
-const tableBody = createStaticBoxBody(world, {
-  width: TABLE_WIDTH,
-  height: TABLE_THICKNESS,
-  depth: TABLE_DEPTH,
-  position: table.position,
-  material: "table",
-  type: "table",
+const socket = initNetwork({
+  onStateUpdated: () => {
+    hud.textContent = `status=${gameState.status} score=${gameState.score} balls=${gameState.ballsLeft} last=${gameState.lastEvent ?? "-"}`;
+    if (gameState.status === "playing" && pendingRespawn) {
+      ball?.resetBall();
+      drainWatcher.canLoseBall = true;
+      pendingRespawn = false;
+    }
+    if (gameState.status === "playing" && gameState.lastEvent === "start_game") {
+      ball?.resetBall();
+      drainWatcher.canLoseBall = true;
+      pendingRespawn = false;
+    }
+    if (gameState.status === "game_over") {
+      pendingRespawn = false;
+      drainWatcher.canLoseBall = true;
+      ball?.resetBall();
+    }
+  },
 });
-syncPairs.push({ mesh: table, body: tableBody });
 
-// ── Murs ───────────────────────────────────────────────
-function createWall(w, h, d, x, y, z) {
-  const mesh = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), wallMat);
+function addStaticBoxVisual(width, height, depth, x, y, z, type = "wall", material = wallMat, physicsMaterial = "static") {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(width, height, depth), material);
   mesh.position.set(x, y, z);
   scene.add(mesh);
-
   const body = createStaticBoxBody(world, {
-    width: w,
-    height: h,
-    depth: d,
+    width,
+    height,
+    depth,
     position: { x, y, z },
+    material: physicsMaterial,
+    type,
   });
   syncPairs.push({ mesh, body });
-
-  return mesh;
 }
 
-// Mur gauche
-createWall(
-  WALL_THICKNESS, WALL_HEIGHT, TABLE_DEPTH,
-  -TABLE_WIDTH / 2 - WALL_THICKNESS / 2,
-  WALL_HEIGHT / 2,
-  0,
-);
+addStaticBoxVisual(TABLE_WIDTH, TABLE_THICKNESS, TABLE_DEPTH, 0, -TABLE_THICKNESS / 2, 0, "table", tableMat, "table");
+addStaticBoxVisual(WALL_THICKNESS, WALL_HEIGHT, TABLE_DEPTH, -TABLE_WIDTH / 2 - WALL_THICKNESS / 2, WALL_HEIGHT / 2, 0);
+addStaticBoxVisual(WALL_THICKNESS, WALL_HEIGHT, TABLE_DEPTH, TABLE_WIDTH / 2 + WALL_THICKNESS / 2, WALL_HEIGHT / 2, 0);
+addStaticBoxVisual(TABLE_WIDTH + WALL_THICKNESS * 2, WALL_HEIGHT, WALL_THICKNESS, 0, WALL_HEIGHT / 2, -TABLE_DEPTH / 2 - WALL_THICKNESS / 2);
 
-// Mur droit
-createWall(
-  WALL_THICKNESS, WALL_HEIGHT, TABLE_DEPTH,
-  TABLE_WIDTH / 2 + WALL_THICKNESS / 2,
-  WALL_HEIGHT / 2,
-  0,
-);
-
-// Mur haut (fond du plateau)
-createWall(
-  TABLE_WIDTH + WALL_THICKNESS * 2, WALL_HEIGHT, WALL_THICKNESS,
-  0,
-  WALL_HEIGHT / 2,
-  -TABLE_DEPTH / 2 - WALL_THICKNESS / 2,
-);
-
-// Mur bas — deux segments avec ouverture drain au centre
 const bottomWallWidth = (TABLE_WIDTH - DRAIN_OPENING_WIDTH) / 2;
 const bottomZ = TABLE_DEPTH / 2 + WALL_THICKNESS / 2;
+addStaticBoxVisual(bottomWallWidth, WALL_HEIGHT, WALL_THICKNESS, -(DRAIN_OPENING_WIDTH / 2 + bottomWallWidth / 2), WALL_HEIGHT / 2, bottomZ);
+addStaticBoxVisual(bottomWallWidth, WALL_HEIGHT, WALL_THICKNESS, DRAIN_OPENING_WIDTH / 2 + bottomWallWidth / 2, WALL_HEIGHT / 2, bottomZ);
 
-// Segment bas-gauche
-createWall(
-  bottomWallWidth, WALL_HEIGHT, WALL_THICKNESS,
-  -(DRAIN_OPENING_WIDTH / 2 + bottomWallWidth / 2),
-  WALL_HEIGHT / 2,
-  bottomZ,
-);
+const bumpers = createBumpers(scene, world);
+syncPairs.push(...bumpers);
 
-// Segment bas-droit
-createWall(
-  bottomWallWidth, WALL_HEIGHT, WALL_THICKNESS,
-  (DRAIN_OPENING_WIDTH / 2 + bottomWallWidth / 2),
-  WALL_HEIGHT / 2,
-  bottomZ,
-);
-
-// ── Bille ──────────────────────────────────────────────
-const ball = createBall(scene, world);
-syncPairs.push(ball);
-
-// ── Flippers ──────────────────────────────────────────
 const flippers = createFlippers(scene, world);
-syncPairs.push(flippers.left, flippers.right);
+syncPairs.push(
+  { mesh: flippers.left.mesh, body: flippers.left.body },
+  { mesh: flippers.right.mesh, body: flippers.right.body },
+);
 
-// ── Bumpers ─────────────────────────────────────────
-const bumperPairs = createBumpers(scene, world);
-syncPairs.push(...bumperPairs);
+ball = createBall(scene, world);
+syncPairs.push({ mesh: ball.mesh, body: ball.body });
 
-// ── Reseau Socket.io ──────────────────────────────────
-const socket = initNetwork({
-  onGameStarted() {
-    resetBall(ball);
-    resetDrainFlag();
-    console.log("[main] game started — bille au spawn");
-  },
-  onGameOver(data) {
-    console.log("[main] game over — score final :", data.score);
-  },
-});
+attachCollisionEmitter(ball.body, (type) => emitCollision(socket, type));
 
-// ── Collisions ────────────────────────────────────────
-setupCollisionListeners(socket, ball.body);
+function tryLaunch() {
+  if (gameState.status !== "playing") return;
+  const speed = ball.body.velocity.length();
+  if (speed > 1.4) return;
+  const dx = ball.body.position.x - PLUNGER_SPAWN_X;
+  const dy = ball.body.position.y - PLUNGER_SPAWN_Y;
+  const dz = ball.body.position.z - PLUNGER_SPAWN_Z;
+  const distFromSpawn = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  if (distFromSpawn > 2.1) return;
 
-// ── Clavier : plunger (Espace), start (S), flippers (fleches), debug (R) ──
-window.addEventListener("keydown", (e) => {
-  if (e.repeat) return;
+  emitLaunchBall(socket);
+  ball.body.wakeUp();
+  ball.body.applyImpulse(new CANNON.Vec3(0, 0.35, LAUNCH_IMPULSE_Z), ball.body.position);
+}
 
-  if (e.code === "Space") {
-    e.preventDefault();
-    if (gameState.status === "playing" && launchBall(ball)) {
-      emitLaunchBall(socket);
-    }
-  }
+window.addEventListener("keydown", (event) => {
+  if (event.repeat) return;
 
-  if (e.code === "KeyS") {
+  if (event.code === "Enter") {
     emitStartGame(socket);
+    return;
   }
 
-  if (e.code === "ArrowLeft") {
-    e.preventDefault();
+  if (event.code === "Space") {
+    tryLaunch();
+    return;
+  }
+
+  if (event.code === "ArrowLeft") {
     setFlipperActive(flippers, "left", true);
     emitFlipperLeftDown(socket);
+    return;
   }
-  if (e.code === "ArrowRight") {
-    e.preventDefault();
+
+  if (event.code === "ArrowRight") {
     setFlipperActive(flippers, "right", true);
     emitFlipperRightDown(socket);
   }
-
-  if (e.code === "KeyR") {
-    resetBall(ball);
-  }
 });
 
-window.addEventListener("keyup", (e) => {
-  if (e.code === "ArrowLeft") {
+window.addEventListener("keyup", (event) => {
+  if (event.code === "ArrowLeft") {
     setFlipperActive(flippers, "left", false);
     emitFlipperLeftUp(socket);
+    return;
   }
-  if (e.code === "ArrowRight") {
+  if (event.code === "ArrowRight") {
     setFlipperActive(flippers, "right", false);
     emitFlipperRightUp(socket);
   }
 });
 
-// ── Resize ─────────────────────────────────────────────
 window.addEventListener("resize", () => {
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);
 });
 
-// ── Boucle de rendu + physique ─────────────────────────
-let lastTime = performance.now();
+const clock = new THREE.Clock();
+
 function animate() {
   requestAnimationFrame(animate);
-
-  const now = performance.now();
-  // Clamp pour eviter un gros step apres un onglet en arriere-plan.
-  const delta = Math.min((now - lastTime) / 1000, 0.1);
-  lastTime = now;
+  const dt = Math.min(0.033, clock.getDelta());
 
   updateFlippers(flippers);
-  world.step(FIXED_TIME_STEP, delta, MAX_SUB_STEPS);
+  world.step(FIXED_TIME_STEP, dt, MAX_SUB_STEPS);
   postStepFlippers(flippers);
-  clampBall(ball);
 
-  // Verifier si la bille est dans le drain apres le step physique.
-  if (checkDrain(socket, ball.body, gameState.status)) {
-    resetBall(ball);
-    resetDrainFlag();
+  if (ball.body.velocity.length() > LAUNCH_MAX_SPEED) {
+    ball.body.velocity.scale(LAUNCH_MAX_SPEED / ball.body.velocity.length(), ball.body.velocity);
+  }
+
+  const lost = detectDrain(ball.body, drainWatcher);
+  if (lost && gameState.status === "playing") {
+    emitCollision(socket, "drain");
+    emitBallLost(socket);
+    pendingRespawn = true;
+    ball.body.velocity.set(0, 0, 0);
+    ball.body.angularVelocity.set(0, 0, 0);
+    ball.body.position.set(0, -4, 0);
   }
 
   syncMeshesWithBodies(syncPairs);
-
   renderer.render(scene, camera);
 }
 

--- a/playfield/src/physics.js
+++ b/playfield/src/physics.js
@@ -12,7 +12,7 @@
  */
 import * as CANNON from "cannon-es";
 
-const TILT_DEG = 12;
+const TILT_DEG = 7;
 const GRAVITY = 9.82;
 
 export const FIXED_TIME_STEP = 1 / 120;
@@ -43,7 +43,9 @@ export function createPhysicsWorld() {
     GRAVITY * Math.sin(tilt),
   );
   world.broadphase = new CANNON.NaiveBroadphase();
-  world.solver.iterations = 15;
+  world.solver.iterations = 20;
+  world.defaultContactMaterial.friction = 0.26;
+  world.defaultContactMaterial.restitution = 0.02;
   return world;
 }
 


### PR DESCRIPTION
## Summary

- Intègre le playfield dans une boucle MVP jouable de bout en bout avec le serveur Socket.io (start, launch, collisions, ball_lost, game_over, restart).
- Aligne la scène et les collisions du bas de plateau (guides proches des flippers, tunnel droit, butées) pour éviter les blocages et sorties de bille qui empêchaient de terminer une partie complète.
- Stabilise la physique MVP (friction/restitution/damping/pente/impulsion) pour limiter les rebonds parasites et obtenir un comportement plus cohérent pendant les tests d’intégration.

## Changes

- `playfield/src/main.js`
  - Branche les modules gameplay (`physics`, `network`, `ball`, `flippers`, `bumpers`, `collisions`) dans la boucle principale.
  - Ajoute le flux réseau complet côté playfield :
    - `Enter` -> `start_game`
    - `Space` -> `launch_ball`
    - `ArrowLeft/ArrowRight` -> `flipper_*`
    - drain -> `collision:drain` + `ball_lost`
  - Ajoute HUD de debug (`status`, `score`, `balls`, `lastEvent`) basé sur `state_updated`.
  - Ajuste les éléments de level-design MVP :
    - coins hauts chanfreinés,
    - guides anti-blocage près des flippers (gauche/droite indépendants),
    - tunnel droit + butée basse,
    - vitre transparente de confinement.
  - Renforce la hauteur/profondeur des obstacles critiques pour éviter que la bille passe “sous” les meshes.
  - Ajoute des garde-fous anti-sortie pour conserver un état de partie cohérent.

- `playfield/src/constants.js`
  - Ajoute/ajuste les constantes gameplay nécessaires (bille, launch, flippers, bumpers, drain, cooldown collisions).
  - Réaligne les valeurs de spawn et de dimensions avec la scène effective.

- `playfield/src/ball.js`
  - Crée/alimente le body Cannon de la bille avec paramètres de damping réalistes.
  - Configure les contact materials `ball<->static` et `ball<->table`.
  - Expose `resetBall()` cohérent avec le flux serveur.

- `playfield/src/collisions.js`
  - Détection des collisions typées + émission `collision { type }` avec anti-spam.
  - Détection de drain logique + verrouillage pour éviter les doubles `ball_lost`.

- `playfield/src/physics.js`
  - Ajuste la pente gravitationnelle et les paramètres globaux de contact/solver pour réduire les rebonds incohérents.

- `playfield/src/flippers.js`
  - Ajuste le contact material flipper/bille pour limiter les catapultages non réalistes.

- `playfield/src/bumpers.js`
  - Ajuste la restitution bumper pour rester jouable en MVP sans comportements extrêmes.

- `docs/MVP_INTEGRATION_TEST.md`
  - Ajoute une procédure “copier-coller” pour lancer les 4 apps.
  - Documente le scénario de test complet de validation d’intégration (start -> launch -> score -> ball_lost -> game_over -> restart).

## Scope / Non-goals

- Pas de polish final physique/perf/accessibilité (étape 14).
- Pas d’ajout de features hors MVP (audio, combo, nudge, ESP32, etc.).
- Objectif : robustesse MVP pour terminer une partie complète et valider la synchro multi-écrans.

## Test plan

- [ ] Lancer les 4 apps :
  - [ ] `cd server && npm run dev`
  - [ ] `cd playfield && npm run dev`
  - [ ] `cd backglass && npm run dev`
  - [ ] `cd dmd && npm run dev`
- [ ] Vérifier `Enter` -> `start_game` -> `status=playing` -> DMD `BALL 1` -> backglass à jour
- [ ] Vérifier `Space` -> `launch_ball` + lancement cohérent
- [ ] Vérifier collisions (murs/flippers/bumpers) -> score serveur -> synchro backglass/DMD
- [ ] Vérifier drain -> `ball_lost` -> décrément billes + respawn
- [ ] Vérifier 3e perte -> `game_over` cohérent sur playfield/backglass/DMD
- [ ] Vérifier restart avec `Enter` après game over
- [ ] Vérifier absence d’erreurs console bloquantes côté serveur et navigateur

## Notes

- Cette PR vise la **validation d’intégration MVP** : partie complète jouable et synchronisée, plutôt qu’un rendu physique final “arcade perfect”.
- Les derniers ajustements de géométrie/confinement sont orientés anti-blocage pour garantir la fin de partie dans tous les cas.