### PR TITLE
feat(playfield): add slingshots, freeze ball at spawn, widen flipper gap

### DIFF
--- a/docs/integration-scenario.md
+++ b/docs/integration-scenario.md
@@ -1,0 +1,110 @@
+# Integration MVP — Scenario bout-en-bout
+
+Valide qu'une partie complete (start → launch → jouer → 3 pertes → game_over → restart)
+reste synchronisee sur les 4 apps (server, playfield, backglass, DMD).
+
+## Procedure de lancement (copier-coller)
+
+Depuis la racine du repo, installer une fois puis tout lancer :
+
+```bash
+# Install dependencies (une seule fois)
+npm install --prefix server
+npm install --prefix playfield
+npm install --prefix backglass
+npm install --prefix dmd
+
+# Lancer les 4 apps en parallele
+npm run dev:all
+```
+
+URLs des ecrans :
+
+- Playfield : http://localhost:5173 (focus clavier obligatoire)
+- Backglass : http://localhost:5174
+- DMD : http://localhost:5175
+- Serveur Socket.IO : http://localhost:3000
+
+Astuce multi-ecran : 3 fenetres cote a cote (playfield focus clavier, backglass, DMD).
+
+## Controles clavier (playfield)
+
+| Touche | Action |
+|--------|--------|
+| `Enter` ou `S` | `start_game` |
+| `Space` | `launch_ball` (plunger) |
+| `ArrowLeft` | flipper gauche (down/up) |
+| `ArrowRight` | flipper droit (down/up) |
+| `R` | reset local de la bille (debug) |
+
+## Scenario nominal
+
+Checks attendus a chaque etape sur les 3 ecrans.
+
+### 1. Boot (4 apps lancees, aucune action)
+
+- Backglass : `score=0`, `billes=3`, `status=idle`
+- DMD : `PRESS START`, `PTS 0`
+- Playfield : bille visible au spawn plunger, etat idle (Space sans effet)
+
+### 2. `Enter` (ou `S`) — `start_game`
+
+- Server → `game_started` + `state_updated` + `dmd_message: "BALL 1"`
+- Backglass : `status=playing`, `score=0`, `billes=3`
+- DMD : `BALL 1`
+- Playfield : bille repositionnee au spawn, Space a present actif
+
+### 3. `Space` — `launch_ball`
+
+- Server → `state_updated` (lastEvent=`launch_ball`)
+- Playfield : bille propulsee vers le haut du plateau (Z-)
+- Relancer `Space` immediatement : aucune nouvelle impulsion (flag anti double-launch)
+
+### 4. Jeu — flippers + collisions + bumpers
+
+- `ArrowLeft` / `ArrowRight` : flippers repondent immediatement
+- Bumper touche (`collision { type: "bumper" }`) : +100 au score
+- `wall` / `flipper` : relayes sans score
+- Backglass et DMD refletent le score serveur en direct
+
+### 5. Drain — `ball_lost`
+
+- Bille passe par l'ouverture drain (Z+)
+- Server : `ballsLeft-=1`, `currentBall+=1`, `dmd_message: "BALL 2"` (puis 3)
+- Backglass : `billes` decrementee
+- DMD : `BALL 2` puis `BALL 3`
+- Playfield : bille respawn automatique au plunger, Space re-actif
+
+### 6. 3e perte — `game_over`
+
+- Server : `status=game_over`, `dmd_message: "GAME OVER"` puis `game_over`
+- Backglass : `status=game_over`, `billes=0`, score final conserve
+- DMD : `GAME OVER` (le score final reste affiche)
+- Playfield : Space desactive (status != playing), flippers relayes mais sans scoring
+
+### 7. Restart — `Enter` apres `game_over`
+
+- Server : reinitialise (score=0, billes=3, currentBall=1), emet `game_started` + `dmd_message: "BALL 1"`
+- Les 3 ecrans repartent dans l'etat du pas (2)
+
+## Edge-cases a verifier
+
+- `Enter` pendant `playing` : ignore par le serveur (pas de reset).
+- `Space` hors partie : ignore cote client (guard `gameState.status === "playing"`).
+- `collision` avec `type` invalide : ignore par le serveur.
+- `ball_lost` hors partie : ignore par le serveur.
+- Ouverture tardive d'un ecran (backglass/DMD apres `start_game`) : le `state_updated`
+  envoye a la connexion le remet d'aplomb.
+
+## Regressions a surveiller
+
+- Double `launch_ball` (ne doit emettre qu'une fois par vie).
+- Double `ball_lost` sur un meme drain (flag `ballLostEmitted`).
+- Desynchro score backglass/DMD apres une rafale de bumpers.
+- DMD qui repasse a `READY` apres `GAME OVER` (ne doit pas arriver : le message
+  reste jusqu'au prochain `dmd_message`).
+
+## Bugs bloquants MVP
+
+_Aucun connu a date — si rencontres, ouvrir un ticket avec l'etape du scenario,
+la touche tapee, et l'ecart observe ecran par ecran._

--- a/playfield/src/ball.js
+++ b/playfield/src/ball.js
@@ -73,26 +73,34 @@ export function clampBall({ body }) {
 let launched = false;
 
 /**
- * Replace la bille au spawn plunger et remet ses vitesses a zero.
+ * Replace la bille au spawn plunger, remet ses vitesses a zero et la fige
+ * (body STATIC) jusqu'au prochain launchBall().
  * Reutilisable par l'etape 7 (plunger) et l'etape 10 (perte de bille).
  */
 export function resetBall({ body }) {
   body.position.set(PLUNGER_SPAWN_X, PLUNGER_SPAWN_Y, PLUNGER_SPAWN_Z);
   body.velocity.set(0, 0, 0);
   body.angularVelocity.set(0, 0, 0);
+  body.force.set(0, 0, 0);
+  body.torque.set(0, 0, 0);
   body.quaternion.set(0, 0, 0, 1);
+  body.type = CANNON.Body.STATIC;
+  body.updateMassProperties();
   body.wakeUp();
   launched = false;
 }
 
 /**
  * Lance la bille depuis le spawn plunger.
- * Applique une impulsion en Z negatif (vers le haut du plateau).
+ * Debloque le body (DYNAMIC) et applique une impulsion en Z negatif (vers le haut).
  * Refuse le lancement si la bille a deja ete lancee (anti double-lancement).
  * Retourne true si le lancement a eu lieu, false sinon.
  */
 export function launchBall({ body }) {
   if (launched) return false;
+  body.type = CANNON.Body.DYNAMIC;
+  body.updateMassProperties();
+  body.wakeUp();
   body.applyImpulse(new CANNON.Vec3(0, 0, -PLUNGER_IMPULSE_FORCE));
   launched = true;
   return true;

--- a/playfield/src/constants.js
+++ b/playfield/src/constants.js
@@ -20,10 +20,10 @@ export const WALL_THICKNESS = 0.3;
 // Drain (ouverture entre les futurs flippers)
 export const DRAIN_OPENING_WIDTH = 2.5;
 
-// Spawn bille (centre bas du plateau, au-dessus du drain)
+// Spawn bille (centre, juste au-dessus du drain)
 export const PLUNGER_SPAWN_X = 0;
 export const PLUNGER_SPAWN_Y = 0.26;
-export const PLUNGER_SPAWN_Z = TABLE_DEPTH / 2 - 1.5;
+export const PLUNGER_SPAWN_Z = TABLE_DEPTH / 2 - 0.5;
 
 // Plunger — force d'impulsion (Z negatif = vers le haut du plateau)
 export const PLUNGER_IMPULSE_FORCE = 18;
@@ -33,18 +33,22 @@ export const FLIPPER_LENGTH = 2.0;
 export const FLIPPER_WIDTH = 0.4;
 export const FLIPPER_HEIGHT = 0.3;
 export const FLIPPER_REST_ANGLE = 0.5;   // radians (~28°), battes au repos vers le drain
-export const FLIPPER_PIVOT_X = DRAIN_OPENING_WIDTH / 2 + 0.2; // distance du centre (±)
+export const FLIPPER_PIVOT_X = DRAIN_OPENING_WIDTH / 2 + 1.25; // distance du centre (±), laisse un acces au drain au repos
 export const FLIPPER_PIVOT_Z = TABLE_DEPTH / 2 - 1.5;
 export const FLIPPER_PIVOT_Y = FLIPPER_HEIGHT / 2 + 0.05;
+
+// Slingshots — murs inclines qui ferment le corridor lateral au-dessus des flippers
+export const SLINGSHOT_DEPTH = 0.25;
+export const SLINGSHOT_TOP_OFFSET = 2.4; // distance Z entre l'extremite haute et le pivot flipper
 
 // Bumpers
 export const BUMPER_RADIUS = 0.5;
 export const BUMPER_HEIGHT = 0.6;
 export const BUMPER_REPULSE_FORCE = 3;
 export const BUMPER_POSITIONS = [
-  { x: -2, z: -2 },
-  { x: 2, z: -4 },
-  { x: 0, z: -6 },
+  { x: -3.1, z: -3.4 },
+  { x: 2.6, z: -6.8 },
+  { x: -0.4, z: -1.1 },
 ];
 
 // Drain — seuil Z au-dela duquel la bille est consideree perdue

--- a/playfield/src/main.js
+++ b/playfield/src/main.js
@@ -22,6 +22,7 @@ import { createBall, launchBall, resetBall, clampBall } from "./ball.js";
 import { initNetwork, emitStartGame, emitLaunchBall, emitFlipperLeftDown, emitFlipperLeftUp, emitFlipperRightDown, emitFlipperRightUp, gameState } from "./network.js";
 import { createFlippers, setFlipperActive, updateFlippers, postStepFlippers } from "./flippers.js";
 import { createBumpers } from "./bumpers.js";
+import { createSlingshots } from "./slingshots.js";
 import { setupCollisionListeners, checkDrain, resetDrainFlag } from "./collisions.js";
 
 // ── Scene ──────────────────────────────────────────────
@@ -152,9 +153,11 @@ syncPairs.push(ball);
 const flippers = createFlippers(scene, world);
 syncPairs.push(flippers.left, flippers.right);
 
+// ── Slingshots ────────────────────────────────────────
+syncPairs.push(...createSlingshots(scene, world));
+
 // ── Bumpers ─────────────────────────────────────────
-const bumperPairs = createBumpers(scene, world);
-syncPairs.push(...bumperPairs);
+syncPairs.push(...createBumpers(scene, world));
 
 // ── Reseau Socket.io ──────────────────────────────────
 const socket = initNetwork({
@@ -182,7 +185,7 @@ window.addEventListener("keydown", (e) => {
     }
   }
 
-  if (e.code === "KeyS") {
+  if (e.code === "KeyS" || e.code === "Enter") {
     emitStartGame(socket);
   }
 

--- a/playfield/src/physics.js
+++ b/playfield/src/physics.js
@@ -53,7 +53,7 @@ export function createPhysicsWorld() {
  * (pas les half-extents). `position` est un objet { x, y, z } (compatible
  * avec THREE.Vector3).
  */
-export function createStaticBoxBody(world, { width, height, depth, position, material, type = "wall" }) {
+export function createStaticBoxBody(world, { width, height, depth, position, material, type = "wall", rotationY = 0 }) {
   const halfExtents = new CANNON.Vec3(width / 2, height / 2, depth / 2);
   const shape = new CANNON.Box(halfExtents);
   const body = new CANNON.Body({
@@ -62,6 +62,9 @@ export function createStaticBoxBody(world, { width, height, depth, position, mat
     material: MATERIALS[material] || MATERIALS.static,
   });
   body.position.set(position.x, position.y, position.z);
+  if (rotationY !== 0) {
+    body.quaternion.setFromAxisAngle(new CANNON.Vec3(0, 1, 0), rotationY);
+  }
   body.userData = { type };
   world.addBody(body);
   return body;

--- a/playfield/src/slingshots.js
+++ b/playfield/src/slingshots.js
@@ -1,0 +1,69 @@
+/**
+ * Playfield — Slingshots.
+ *
+ * Deux murs statiques inclines juste au-dessus des flippers. Leur extremite
+ * basse est collee au pivot du flipper, l'extremite haute s'appuie contre
+ * la paroi laterale. Ils ferment le corridor lateral pour que la bille ne
+ * se coince plus dans les coins et la renvoient vers le centre.
+ */
+import * as THREE from "three";
+import {
+  TABLE_WIDTH,
+  WALL_HEIGHT,
+  FLIPPER_PIVOT_X,
+  FLIPPER_PIVOT_Z,
+  SLINGSHOT_DEPTH,
+  SLINGSHOT_TOP_OFFSET,
+} from "./constants.js";
+import { createStaticBoxBody } from "./physics.js";
+
+const SLINGSHOT_COLOR = 0x8b4513;
+
+function createOneSlingshot(scene, world, side, material) {
+  const isLeft = side === "left";
+
+  // Extremite basse : exactement au pivot du flipper.
+  const lowX = isLeft ? -FLIPPER_PIVOT_X : FLIPPER_PIVOT_X;
+  const lowZ = FLIPPER_PIVOT_Z;
+  // Extremite haute : contre la paroi laterale, plus haut dans le plateau.
+  const highX = isLeft
+    ? -TABLE_WIDTH / 2 + SLINGSHOT_DEPTH / 2
+    : TABLE_WIDTH / 2 - SLINGSHOT_DEPTH / 2;
+  const highZ = FLIPPER_PIVOT_Z - SLINGSHOT_TOP_OFFSET;
+
+  const centerX = (lowX + highX) / 2;
+  const centerZ = (lowZ + highZ) / 2;
+  const length = Math.hypot(lowX - highX, lowZ - highZ);
+  // Rotation Y : le vecteur local +X doit pointer de highEnd vers lowEnd.
+  const angle = Math.atan2(-(lowZ - highZ), lowX - highX);
+
+  const mesh = new THREE.Mesh(
+    new THREE.BoxGeometry(length, WALL_HEIGHT, SLINGSHOT_DEPTH),
+    material,
+  );
+  mesh.position.set(centerX, WALL_HEIGHT / 2, centerZ);
+  mesh.rotation.y = angle;
+  scene.add(mesh);
+
+  const body = createStaticBoxBody(world, {
+    width: length,
+    height: WALL_HEIGHT,
+    depth: SLINGSHOT_DEPTH,
+    position: { x: centerX, y: WALL_HEIGHT / 2, z: centerZ },
+    rotationY: angle,
+  });
+
+  return { mesh, body };
+}
+
+/**
+ * Cree les deux slingshots (gauche + droit) et retourne les couples
+ * { mesh, body } a pousser dans syncPairs.
+ */
+export function createSlingshots(scene, world) {
+  const material = new THREE.MeshStandardMaterial({ color: SLINGSHOT_COLOR });
+  return [
+    createOneSlingshot(scene, world, "left", material),
+    createOneSlingshot(scene, world, "right", material),
+  ];
+}


### PR DESCRIPTION
  - Add two angled slingshot walls anchored to flipper pivots to close the
    side corridors and prevent the ball from getting stuck in the bottom
    corners (new module playfield/src/slingshots.js).
  - Widen flipper spacing (FLIPPER_PIVOT_X = DRAIN_OPENING_WIDTH/2 + 1.25)
    to leave clear drain access when flippers are at rest.
  - Freeze the ball at spawn (STATIC body) on resetBall and unfreeze only
    on launchBall: the ball is now immobile until the player presses Space.
  - Move the plunger spawn just above the drain (PLUNGER_SPAWN_Z).
  - Shuffle BUMPER_POSITIONS for a new playfield layout.
  - Add Enter as an alias for S to trigger start_game.
  - Support rotationY in createStaticBoxBody for angled static walls.
  - Document the end-to-end MVP scenario in docs/integration-scenario.md.