### PR TITLE
[MVP][IoT-ready] Abstraire les inputs du playfield pour préparer les contrôleurs physiques

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -103,3 +103,51 @@ Autres valeurs observees en MVP: `"BALL 2"`, `"BALL 3"`, `"GAME OVER"`.
 - Si `collision` a un `type` invalide, le serveur ignore.
 - Si `ball_lost` est envoye hors partie (`status !== "playing"`), le serveur ignore.
 - Les events flippers (`flipper_*`) sont relays en broadcast aux autres clients.
+
+## Couche d'input Playfield (clavier / futur IoT)
+
+Le playfield utilise une couche d'abstraction d'inputs dans `playfield/src/input.js`.
+
+But :
+- decoupler la logique de jeu des peripheriques concrets,
+- garder le clavier comme source actuelle,
+- permettre plus tard de brancher un ESP32/Arduino sans refactor majeur.
+
+### Actions exposees par la couche input
+
+- `start()`
+- `launch()`
+- `leftFlipperDown()`
+- `leftFlipperUp()`
+- `rightFlipperDown()`
+- `rightFlipperUp()`
+- `debugResetBall()`
+
+### Mapping clavier actuel
+
+- Start : `S`, `D`, `Enter`, `NumpadEnter`
+- Launch : `Space`
+- Flipper gauche : `ArrowLeft`
+- Flipper droit : `ArrowRight`
+- Reset debug : `R`
+
+### Integration future ESP32 / Arduino
+
+Quand les inputs physiques seront disponibles, ils ne devront pas appeler
+directement la logique du playfield ou les emits Socket.
+
+Ils devront uniquement appeler les actions de la couche input, par exemple :
+
+```js
+controller.start();
+controller.leftFlipperDown();
+controller.leftFlipperUp();
+controller.rightFlipperDown();
+controller.rightFlipperUp();
+controller.launch();
+```
+
+Ainsi :
+- le clavier et l'IoT partagent exactement le meme chemin logique,
+- les regles de jeu restent centralisees,
+- le branchement materiel futur se fait sans dupliquer la logique.

--- a/playfield/src/input.js
+++ b/playfield/src/input.js
@@ -1,0 +1,110 @@
+/**
+ * Playfield — Couche d'abstraction des inputs.
+ *
+ * Objectif :
+ * - decoupler la logique de jeu des peripheriques concrets (clavier, ESP32, Arduino...)
+ * - exposer une API d'actions de haut niveau reutilisable
+ *
+ * Une source d'input future (IoT/serie/WebSocket local/MQTT...) devra simplement
+ * appeler les actions exposees par `createGameInputController()`.
+ */
+
+/**
+ * Cree un controleur d'input a partir de callbacks metier.
+ */
+export function createGameInputController(actions) {
+  return {
+    start() {
+      actions.onStart?.();
+    },
+    launch() {
+      actions.onLaunch?.();
+    },
+    leftFlipperDown() {
+      actions.onLeftFlipperDown?.();
+    },
+    leftFlipperUp() {
+      actions.onLeftFlipperUp?.();
+    },
+    rightFlipperDown() {
+      actions.onRightFlipperDown?.();
+    },
+    rightFlipperUp() {
+      actions.onRightFlipperUp?.();
+    },
+    debugResetBall() {
+      actions.onDebugResetBall?.();
+    },
+  };
+}
+
+/**
+ * Branche le clavier sur la couche d'input.
+ *
+ * Mapping actuel :
+ * - Start : S, D, Enter, NumpadEnter
+ * - Launch : Space
+ * - Flipper gauche : ArrowLeft
+ * - Flipper droit : ArrowRight
+ * - Debug reset : R
+ *
+ * Retourne une fonction de cleanup.
+ */
+export function bindKeyboardInput(controller, target = window) {
+  function onKeyDown(event) {
+    if (event.repeat) return;
+
+    if (event.code === "Space") {
+      event.preventDefault();
+      controller.launch();
+      return;
+    }
+
+    if (
+      event.code === "KeyS"
+      || event.code === "KeyD"
+      || event.code === "Enter"
+      || event.code === "NumpadEnter"
+      || event.key === "Enter"
+    ) {
+      event.preventDefault();
+      controller.start();
+      return;
+    }
+
+    if (event.code === "ArrowLeft") {
+      event.preventDefault();
+      controller.leftFlipperDown();
+      return;
+    }
+
+    if (event.code === "ArrowRight") {
+      event.preventDefault();
+      controller.rightFlipperDown();
+      return;
+    }
+
+    if (event.code === "KeyR") {
+      controller.debugResetBall();
+    }
+  }
+
+  function onKeyUp(event) {
+    if (event.code === "ArrowLeft") {
+      controller.leftFlipperUp();
+      return;
+    }
+
+    if (event.code === "ArrowRight") {
+      controller.rightFlipperUp();
+    }
+  }
+
+  target.addEventListener("keydown", onKeyDown);
+  target.addEventListener("keyup", onKeyUp);
+
+  return function unbindKeyboardInput() {
+    target.removeEventListener("keydown", onKeyDown);
+    target.removeEventListener("keyup", onKeyUp);
+  };
+}

--- a/playfield/src/main.js
+++ b/playfield/src/main.js
@@ -24,6 +24,7 @@ import { createFlippers, setFlipperActive, updateFlippers, postStepFlippers } fr
 import { createBumpers } from "./bumpers.js";
 import { createSlingshots } from "./slingshots.js";
 import { setupCollisionListeners, checkDrain, resetDrainFlag } from "./collisions.js";
+import { createGameInputController, bindKeyboardInput } from "./input.js";
 
 // ── Scene ──────────────────────────────────────────────
 const scene = new THREE.Scene();
@@ -174,55 +175,38 @@ const socket = initNetwork({
 // ── Collisions ────────────────────────────────────────
 setupCollisionListeners(socket, ball.body);
 
-// ── Clavier : plunger (Espace), start (S), flippers (fleches), debug (R) ──
-window.addEventListener("keydown", (e) => {
-  if (e.repeat) return;
-
-  if (e.code === "Space") {
-    e.preventDefault();
+const inputController = createGameInputController({
+  onStart() {
+    console.log("[input] emit start_game");
+    emitStartGame(socket);
+  },
+  onLaunch() {
     if (gameState.status === "playing" && launchBall(ball)) {
       emitLaunchBall(socket);
     }
-  }
-
-  if (
-    e.code === "KeyS"
-    || e.code === "KeyD"
-    || e.code === "Enter"
-    || e.code === "NumpadEnter"
-    || e.key === "Enter"
-  ) {
-    e.preventDefault();
-    console.log("[main] emit start_game");
-    emitStartGame(socket);
-  }
-
-  if (e.code === "ArrowLeft") {
-    e.preventDefault();
+  },
+  onLeftFlipperDown() {
     setFlipperActive(flippers, "left", true);
     emitFlipperLeftDown(socket);
-  }
-  if (e.code === "ArrowRight") {
-    e.preventDefault();
-    setFlipperActive(flippers, "right", true);
-    emitFlipperRightDown(socket);
-  }
-
-  if (e.code === "KeyR") {
-    resetBall(ball);
-  }
-});
-
-window.addEventListener("keyup", (e) => {
-  if (e.code === "ArrowLeft") {
+  },
+  onLeftFlipperUp() {
     setFlipperActive(flippers, "left", false);
     emitFlipperLeftUp(socket);
-  }
-  if (e.code === "ArrowRight") {
+  },
+  onRightFlipperDown() {
+    setFlipperActive(flippers, "right", true);
+    emitFlipperRightDown(socket);
+  },
+  onRightFlipperUp() {
     setFlipperActive(flippers, "right", false);
     emitFlipperRightUp(socket);
-  }
+  },
+  onDebugResetBall() {
+    resetBall(ball);
+  },
 });
+
+bindKeyboardInput(inputController);
 
 // ── Resize ─────────────────────────────────────────────
 window.addEventListener("resize", () => {


### PR DESCRIPTION
- Ajouter une couche `input` dédiée pour découpler les actions de jeu des périphériques concrets
- Brancher le clavier sur cette abstraction sans changer le comportement actuel des flippers et du start
- Préparer l’intégration future d’inputs physiques (ESP32/Arduino) sans refactor majeur du gameplay
- Documenter dans `docs/EVENTS.md` le rôle de la couche input, le mapping clavier actuel et l’interface attendue pour l’IoT