### PR TITLE
fix(flipper) feat(dmd/backglass): anti-tunneling, per-ball DMD messag…

### DIFF
--- a/backglass/src/renderer/mount.js
+++ b/backglass/src/renderer/mount.js
@@ -103,6 +103,7 @@ export function mountBackglassRoot() {
           <div class="backglass__metric-label">lls left</div>
           <div id="ballsLeftValue" class="backglass__balls" role="img" aria-label="Balles restantes">
             ${methBag()}${methBag()}${methBag()}
+            <span id="ballsCount" class="backglass__balls-count">3/3</span>
           </div>
         </div>
       </div>
@@ -153,6 +154,7 @@ export function mountBackglassRoot() {
         <div class="attract-screen__hint">Insert coin · 1 credit</div>
       </div>
     </div>
+    <div id="backglass-warm" class="backglass-warm" aria-hidden="true"></div>
   `;
 
   document.body.append(app);
@@ -161,6 +163,7 @@ export function mountBackglassRoot() {
     root: app,
     scoreValue: document.getElementById("scoreValue"),
     ballsLeftValue: document.getElementById("ballsLeftValue"),
+    ballsCount: document.getElementById("ballsCount"),
     ballIcons: Array.from(app.querySelectorAll(".backglass__ball")),
     highscoreValue: document.getElementById("highscoreValue"),
     highscorePopup: document.getElementById("highscore-popup"),

--- a/backglass/src/renderer/view.js
+++ b/backglass/src/renderer/view.js
@@ -93,7 +93,8 @@ function createCountUp(el, { punch = false } = {}) {
 }
 
 export function createBackglassView(refs) {
-  const { scoreValue, ballsLeftValue, highscoreValue, ballIcons, ballLossOverlay } = refs;
+  const { scoreValue, ballsLeftValue, highscoreValue, ballIcons, ballsCount, ballLossOverlay } = refs;
+  const TOTAL_BALLS = Array.isArray(ballIcons) ? ballIcons.length : 3;
   let prevBallsLeft = null;
   let ballLossTimer = 0;
 
@@ -142,6 +143,9 @@ export function createBackglassView(refs) {
       ballIcons.forEach((icon, index) => {
         icon.classList.toggle("lost", index >= ballsLeft);
       });
+    }
+    if (ballsCount) {
+      ballsCount.textContent = `${Math.max(0, ballsLeft)}/${TOTAL_BALLS}`;
     }
     if (prevBallsLeft !== null && ballsLeft < prevBallsLeft) {
       // Le sachet qui vient d'être perdu est celui d'index `ballsLeft` (0-based).

--- a/backglass/src/styles.css
+++ b/backglass/src/styles.css
@@ -68,6 +68,11 @@ body {
   grid-template-columns: minmax(140px, 200px) auto 1fr;
   gap: 1rem;
   align-items: center;
+  /* Cadre par ligne : regroupe visuellement le libellé et sa valeur. */
+  border: 2px solid rgba(215, 195, 110, 0.4);
+  border-radius: 16px;
+  padding: 0.5rem 1.6rem;
+  background: rgba(20, 10, 4, 0.28);
   /* Animation idle : flottement vertical + dérive latérale, décalé par ligne (effet vague) */
   animation: row-float 7s ease-in-out infinite;
   will-change: transform;
@@ -149,10 +154,27 @@ body {
 
 /* Balls left — sachets de "blue meth" */
 .backglass__balls {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: clamp(0.4rem, 1vw, 1rem);
+}
+
+/* Compteur "X/3" superpose aux sachets pour rendre le nombre de balles explicite */
+.backglass__balls-count {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'BackglassData', sans-serif;
+  font-size: clamp(2.4rem, 3.6vw, 4.4rem);
+  letter-spacing: 0.05em;
+  color: #fff;
+  -webkit-text-stroke: 1.5px rgba(0, 0, 0, 0.65);
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.85), 0 0 16px rgba(57, 182, 255, 0.6);
+  pointer-events: none;
 }
 
 .backglass__ball {
@@ -169,7 +191,7 @@ body {
 
 /* Balle perdue : le sachet se vide (atténué + désaturé + légèrement réduit) */
 .backglass__ball.lost {
-  opacity: 0.2;
+  opacity: 0.45;
   filter: grayscale(0.85) drop-shadow(0 0 2px rgba(0, 0, 0, 0.4));
   transform: scale(0.88);
 }
@@ -938,4 +960,24 @@ body {
   .backglass__metric-value {
     transition: none;
   }
+}
+
+/* Calque chaud "coucher de soleil" : tinte le FOND du backglass en orange pour
+   le relier au playfield. pointer-events:none. z-index 0 = au-dessus du fond
+   (.backglass__background, z auto) mais SOUS le contenu (.backglass__overlay
+   score/texte, z 1) -> le texte reste net par-dessus la teinte.
+   Le degrade est plus dense en bas-droite, comme la lumiere du playfield. */
+.backglass-warm {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  /* Film orange en blend normal : rechauffe franchement tout l'ecran, plus
+     dense vers le bas-droite (comme la lumiere du playfield). */
+  background: radial-gradient(
+    135% 105% at 72% 110%,
+    rgba(255, 96, 18, 0.5) 0%,
+    rgba(255, 122, 40, 0.32) 48%,
+    rgba(255, 150, 70, 0.18) 100%
+  );
 }

--- a/dmd/src/__tests__/wireDmdNetwork.test.js
+++ b/dmd/src/__tests__/wireDmdNetwork.test.js
@@ -19,6 +19,7 @@ describe("wireDmdNetwork", () => {
     renderer = {
       renderScore: vi.fn(),
       updateStatus: vi.fn(),
+      flashBallMessage: vi.fn(),
     };
     callbacks = {};
     initNetwork.mockImplementation((cbs) => { callbacks = cbs; });
@@ -54,5 +55,16 @@ describe("wireDmdNetwork", () => {
     expect(renderer.renderScore).toHaveBeenCalledWith(0);
     expect(renderer.updateStatus).toHaveBeenCalledWith("playing");
     expect(refs.stateStatus.textContent).toBe("state: playing");
+  });
+
+  it("6 — onDmdMessage 'BALL 2' declenche flashBallMessage", () => {
+    callbacks.onDmdMessage("BALL 2");
+    expect(renderer.flashBallMessage).toHaveBeenCalledWith("BALL 2");
+  });
+
+  it("7 — onDmdMessage ignore les messages non-BALL (GAME OVER, PRESS START)", () => {
+    callbacks.onDmdMessage("GAME OVER");
+    callbacks.onDmdMessage("PRESS START");
+    expect(renderer.flashBallMessage).not.toHaveBeenCalled();
   });
 });

--- a/dmd/src/composition/wireDmdNetwork.js
+++ b/dmd/src/composition/wireDmdNetwork.js
@@ -21,9 +21,13 @@ export function wireDmdNetwork({ refs, renderer }) {
     onConnectionError() {
       socketStatus.textContent = "socket: error";
     },
-    onDmdMessage() {
-      // Ignore arbitrary DMD messages so the display remains limited to the
-      // three expected states: PRESS START, POINTS, GAME OVER.
+    onDmdMessage(text) {
+      // On n'affiche que les messages "BALL N" (flash bref a chaque nouvelle
+      // bille, puis retour aux POINTS). Les autres (PRESS START, GAME OVER)
+      // restent pilotes par le `status` via onStateUpdated/onGameOver.
+      if (typeof text === "string" && text.trim().toUpperCase().startsWith("BALL")) {
+        renderer.flashBallMessage(text);
+      }
     },
     onStateUpdated(data) {
       renderer.renderScore(data?.score);

--- a/dmd/src/renderer/dotMatrix.js
+++ b/dmd/src/renderer/dotMatrix.js
@@ -49,6 +49,11 @@ export function createDotMatrixRenderer(canvas) {
     status: "idle",
   };
 
+  // Affichage temporaire "BALL N" : pendant `playing`, prend le pas sur POINTS
+  // jusqu'a `until`, puis l'affichage revient automatiquement aux points.
+  const flashState = { text: null, until: 0 };
+  const BALL_FLASH_MS = 2000;
+
   const scrollState = {
     offsetX: TEXT_MARGIN,
     pauseUntil: 0,
@@ -122,6 +127,19 @@ export function createDotMatrixRenderer(canvas) {
   function getCurrentText() {
     if (scrollState.isTransition) {
       return scrollState.text;
+    }
+    return getTextForStatus(dmdState.status);
+  }
+
+  // Texte affiche en mode statique : le flash "BALL N" prime sur les POINTS
+  // pendant `playing`, le temps de la fenetre `flashState.until`.
+  function getStaticDisplayText() {
+    if (
+      flashState.text &&
+      dmdState.status === "playing" &&
+      performance.now() < flashState.until
+    ) {
+      return flashState.text;
     }
     return getTextForStatus(dmdState.status);
   }
@@ -237,8 +255,9 @@ export function createDotMatrixRenderer(canvas) {
       textWidth = scrollState.textWidth;
       textX = Math.floor(scrollState.offsetX);
     } else {
-      // Otherwise render the canonical text for the current status, centered.
-      text = getTextForStatus(dmdState.status);
+      // Otherwise render the canonical text for the current status (ou le flash
+      // "BALL N" en cours), centré.
+      text = getStaticDisplayText();
       textWidth = measureTextWidth(text);
       textX = Math.round((DOT_COLS - textWidth) / 2);
     }
@@ -350,6 +369,20 @@ export function createDotMatrixRenderer(canvas) {
 
       // For other statuses (playing), just update the stored message so it can
       // be used when returning to idle or for transitions triggered by status.
+      render();
+    },
+
+    /**
+     * Affiche brievement "BALL N" par-dessus les POINTS (pendant `playing`),
+     * puis revient automatiquement aux points a l'expiration de la fenetre.
+     */
+    flashBallMessage(text, ms = BALL_FLASH_MS) {
+      flashState.text = normalizeMessage(text);
+      flashState.until = performance.now() + ms;
+      // Coupe tout scroll/transition en cours pour montrer le flash centre tout
+      // de suite ; le retour aux POINTS se fait via getStaticDisplayText.
+      scrollState.active = false;
+      scrollState.isTransition = false;
       render();
     },
 

--- a/playfield/src/adapters/physics/rapier/flipperBody.js
+++ b/playfield/src/adapters/physics/rapier/flipperBody.js
@@ -75,6 +75,9 @@ function createOneFlipperBody(world, side) {
     );
 
   const rb = world.createRigidBody(bodyDesc);
+  // CCD : la batte balaie vite (bout ~30 u/s) -> sans CCD elle traverse la bille
+  // en un pas physique. Active le sweep continu du flipper (la bille a deja CCD).
+  rb.enableCcd(true);
 
   // Box collider decalee : extension geometrique de la batte autour du pivot.
   // Densite 0 pour que le collider ne deplace pas le COM (cf. note ci-dessus).


### PR DESCRIPTION
…e, backglass readability                               

  Playfield:
  - Enable CCD on the flipper bodies so a fast swing no longer tunnels through the ball (the ball already had CCD; the flipper is the fast mover)

  DMD:
  - Show "BALL N" briefly at each new ball, then fall back to POINTS (flashBallMessage, driven by the server's dmd_message for BALL* only; GAME OVER / PRESS START stay status-driven)
  - Add tests for the BALL flash wiring

  Backglass:
  - Add a translucent orange "sunset" tint layer behind the content (z-index 0: warms the background, keeps score/text crisp on top) to match the playfield lighting
  - Frame each metric row (score / highscore / balls) with a border so the label and its value read as one line
  - Overlay a "X/3" count on the remaining-ball icons (live-updated)
  - Make lost-ball icons more visible (opacity 0.2 -> 0.45)

  Backglass:
  - Add a translucent orange "sunset" tint layer behind the content (z-index 0: warms the background, keeps score/text crisp on top) to match the playfield lighting
  - Frame each metric row (score / highscore / balls) with a border so the label and its value read as one line
  - Overlay a "X/3" count on the remaining-ball icons (live-updated)
  - Make lost-ball icons more visible (opacity 0.2 -> 0.45)