### PR TITLE
feat(playfield): polish visuals — recolor bumpers, camera shake, refl…

### DIFF
--- a/playfield/src/adapters/renderer/PlayfieldScene.js
+++ b/playfield/src/adapters/renderer/PlayfieldScene.js
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
 import {
   MAX_RENDERER_PIXEL_RATIO,
   RENDERER_ANTIALIAS,
@@ -43,12 +44,23 @@ class PlayfieldScene {
     this.#renderer.setSize(window.innerWidth, window.innerHeight);
     this.#renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, MAX_RENDERER_PIXEL_RATIO));
     this.#renderer.toneMapping = THREE.ReinhardToneMapping;
-    this.#renderer.toneMappingExposure = 1.45;
+    this.#renderer.toneMappingExposure = 1.6;
     this.#renderer.shadowMap.enabled = true;
     this.#renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     document.body.style.margin = "0";
     document.body.style.overflow = "hidden";
     document.body.appendChild(this.#renderer.domElement);
+
+    // Environment map : reflexions douces sur les surfaces metalliques (murs, barils,
+    // bille, triangles) -> rendu bien plus riche que des metaux mats/sombres.
+    const pmrem = new THREE.PMREMGenerator(this.#renderer);
+    this.#scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.08).texture;
+
+    // Vignette cinematique : assombrit legerement les bords pour focaliser le regard.
+    const vignette = document.createElement("div");
+    vignette.style.cssText =
+      "position:fixed;inset:0;pointer-events:none;z-index:5;box-shadow:inset 0 0 240px 70px rgba(0,0,0,0.6)";
+    document.body.appendChild(vignette);
 
     this.#ambientLight = new THREE.AmbientLight(0xffffff, PLAYFIELD_VIEW_DEFAULTS.ambientIntensity);
     this.#scene.add(this.#ambientLight);

--- a/playfield/src/adapters/renderer/modelLoader.js
+++ b/playfield/src/adapters/renderer/modelLoader.js
@@ -1,5 +1,5 @@
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { MeshStandardMaterial, DoubleSide, TextureLoader, SRGBColorSpace } from 'three';
+import { MeshStandardMaterial, DoubleSide, TextureLoader, SRGBColorSpace, Matrix4 } from 'three';
 
 export const GLB_SCALE_X = 1;
 export const GLB_SCALE_Y = 1;
@@ -31,6 +31,7 @@ const MODEL_FILES = {
   'Bumper-barril-1': 'Bumper-barril',
   'Bumper-barril-2': 'Bumper-barril',
   'Bumper-losange2': 'barril', // bumper le plus haut : losange remplace par un baril
+  'Bumper-triangle2': 'Bumper-triangle1', // gauche = meme GLB que le droit, reflechi (symetrie)
 };
 
 const EXTRA_SCALE_X = 6.372;
@@ -50,10 +51,9 @@ const BUMPER_POS = {
   // en milieu-haut du plateau. Geometrie barril centree ~origine -> pos ~= monde.
   'Bumper-barril-1':  { x: 1.425,  y: 0.6, z: -5 },
   'Bumper-barril-2':  { x: -2.975, y: 0.6, z: -5 },
-  // Triangles symetriques autour de l'axe central du jouable (PLAYABLE_CENTER_X = -0.775) :
-  // X miroir (+/-2.70), Z et Y conserves (deja alignes, monde z=3.28 y=0.53).
+  // Triangle droit. Le gauche reutilise ce meme placement puis est reflechi
+  // autour de l'axe central du jouable (voir boucle) -> symetrie parfaite.
   'Bumper-triangle1': { x: 0.034, y: -7.020, z: 0.751 },
-  'Bumper-triangle2': { x: 0.034, y: -7.020, z: 0.765 },
 };
 
 // Le modele barril.glb a une echelle de 100 bakee dans la matrice de son noeud
@@ -63,6 +63,15 @@ const BUMPER_SCALE = {
   'Bumper-losange2': { x: 0.0033, y: 0.0033, z: 0.0033 },
   'Bumper-barril-1': { x: 0.0033, y: 0.0033, z: 0.0033 },
   'Bumper-barril-2': { x: 0.0033, y: 0.0033, z: 0.0033 },
+};
+
+// Rotation propre (en degres) pour certains modeles. Le barril.glb est deja
+// redresse par sa matrice de noeud -> l'EXTRA_ROT (8,-90,16) ne ferait que le
+// pencher. On le laisse donc parfaitement droit.
+const BUMPER_ROT = {
+  'Bumper-losange2': { x: 0, y: -90, z: 0 }, // quart de tour pour redresser le logo
+  'Bumper-barril-1': { x: 0, y: -90, z: 0 },
+  'Bumper-barril-2': { x: 0, y: -90, z: 0 },
 };
 
 class ModelLoader {
@@ -89,15 +98,73 @@ class ModelLoader {
       roughnessMap: tl.load('/textures/bumper_smoothness.png'),
     });
 
+    // Losange : base blanche -> metal rouille gris clair (textures rust_*),
+    // dessus noir -> jaune chantier.
+    const rustAlbedo = tl.load('/textures/rust_color.jpg');
+    rustAlbedo.colorSpace = SRGBColorSpace;
+    const losangeBaseMat = new MeshStandardMaterial({
+      color: 0xf2f2f2, // gris tres clair
+      metalness: 0.60, // bas : sans envMap, metalness eleve assombrit -> on garde l'albedo clair en diffus
+      roughness: 0.9,
+      map:          rustAlbedo,
+      metalnessMap: tl.load('/textures/rust_JPG_Metalness.jpg'),
+      normalMap:    tl.load('/textures/rust_normalGL.jpg'),
+      roughnessMap: tl.load('/textures/rust_roughness.jpg'),
+    });
+    const losangeTopMat = new MeshStandardMaterial({
+      color: 0xffd633, // jaune chantier clair
+      metalness: 0.3,
+      roughness: 0.6,
+    });
+
+    // Triangles (slingshots) : theme meth bleu -> base metal gris clair,
+    // dessus + cylindres en bleu electrique emissif (capte le bloom).
+    // side: DoubleSide car le triangle gauche est reflechi (scale negatif -> normales inversees).
+    const triBaseMat = new MeshStandardMaterial({ color: 0x33383d, metalness: 0.75, roughness: 0.4, side: DoubleSide });
+    const triBlueMat = new MeshStandardMaterial({
+      color: 0x0e7fa8, emissive: 0x22c4ff, emissiveIntensity: 1.2, metalness: 0.25, roughness: 0.3, side: DoubleSide,
+    });
+
     for (const m of scenes) {
       const pos = BUMPER_POS[m.name];
       const sc = BUMPER_SCALE[m.name];
+      const rot = BUMPER_ROT[m.name];
       m.scale.set(sc?.x ?? EXTRA_SCALE_X, sc?.y ?? EXTRA_SCALE_Y, sc?.z ?? EXTRA_SCALE_Z);
-      m.rotation.set(EXTRA_ROT_X * DEG, EXTRA_ROT_Y * DEG, EXTRA_ROT_Z * DEG);
+      m.rotation.set((rot?.x ?? EXTRA_ROT_X) * DEG, (rot?.y ?? EXTRA_ROT_Y) * DEG, (rot?.z ?? EXTRA_ROT_Z) * DEG);
       m.position.set(pos?.x ?? EXTRA_POS_X, pos?.y ?? EXTRA_POS_Y, pos?.z ?? EXTRA_POS_Z);
+
+      // Triangle gauche : meme placement que le droit, puis reflexion autour de
+      // l'axe central du jouable (x = -0.775) -> miroir exact.
+      if (m.name === 'Bumper-triangle2') {
+        const pr = BUMPER_POS['Bumper-triangle1'];
+        m.position.set(pr.x, pr.y, pr.z);
+        m.updateMatrix();
+        const C = -0.775;
+        m.applyMatrix4(new Matrix4().makeTranslation(2 * C, 0, 0).multiply(new Matrix4().makeScale(-1, 1, 1)));
+      }
 
       if (/barril/i.test(MODEL_FILES[m.name] ?? '')) {
         m.traverse((o) => { if (o.isMesh) { o.material = barrilMat; o.frustumCulled = false; } });
+      }
+
+      // Losange : on cible chaque partie par le nom de son materiau d'origine.
+      if (m.name === 'Bumper-losange1') {
+        m.traverse((o) => {
+          if (!o.isMesh) return;
+          if (o.material?.name === 'Mat.1')  o.material = losangeBaseMat; // base blanche -> rouille grise
+          if (o.material?.name === 'Mat.16') o.material = losangeTopMat;  // dessus noir -> jaune chantier
+          // Mat.5 (points rouges) : inchange
+        });
+      }
+
+      // Triangles : base metal gris clair, dessus + cylindres bleu meth emissif.
+      // Les deux utilisent desormais le GLB du droit -> meme mapping (Mat.16 = dessus).
+      if (m.name === 'Bumper-triangle1' || m.name === 'Bumper-triangle2') {
+        m.traverse((o) => {
+          if (!o.isMesh) return;
+          const mn = o.material?.name;
+          o.material = (mn === 'Mat.5' || mn === 'Mat.16') ? triBlueMat : triBaseMat;
+        });
       }
     }
     return scenes;

--- a/playfield/src/composition/ViewRuntime.js
+++ b/playfield/src/composition/ViewRuntime.js
@@ -34,6 +34,7 @@ export default class ViewRuntime {
   #orthoCamera;
   #v = new THREE.Vector3();
   #toView = new THREE.Matrix4();
+  #shakeMag = 0;
 
   params;
 
@@ -51,6 +52,29 @@ export default class ViewRuntime {
   }
 
   getCamera = () => this.#activeCamera;
+
+  /** Declenche une secousse camera (ex: impact bumper). Cumulatif, plafonne. */
+  shake = (intensity = 1) => {
+    this.#shakeMag = Math.min(this.#shakeMag + intensity, 1.5);
+  };
+
+  /** A appeler chaque frame avant le rendu : applique puis attenue la secousse. */
+  tickShake = () => {
+    const cam = this.#activeCamera;
+    if (!cam) return;
+    const p = this.params;
+    if (this.#shakeMag <= 0.001) {
+      cam.position.set(p.cameraPosX, p.cameraPosY, p.cameraPosZ);
+      return;
+    }
+    const amp = 0.22 * this.#shakeMag;
+    cam.position.set(
+      p.cameraPosX + (Math.random() * 2 - 1) * amp,
+      p.cameraPosY + (Math.random() * 2 - 1) * amp,
+      p.cameraPosZ + (Math.random() * 2 - 1) * amp,
+    );
+    this.#shakeMag *= 0.82;
+  };
 
   onResize = () => {
     if (this.params.cameraMode === 'perspective') {

--- a/playfield/src/domain/viewConfig.js
+++ b/playfield/src/domain/viewConfig.js
@@ -30,7 +30,7 @@ export const PLAYFIELD_VIEW_DEFAULTS = {
   // (cf. scene.js, couleur orange chaude + ombres) vient du coin BAS-DROITE hors
   // plateau (X+ = droite, Z+ = bas/joueur), angle rasant -> ombres longues vers
   // le haut du plateau. Ambient baisse pour garder du contraste.
-  ambientIntensity: 0.55,
+  ambientIntensity: 1.0,
   dirLightX: 14,
   dirLightY: 14,
   dirLightZ: 18,

--- a/playfield/src/main.js
+++ b/playfield/src/main.js
@@ -30,7 +30,7 @@ let levelRef = null;
 const collisionHandler = new CollisionHandler({
   onCollision: (type) => {
     network.emitCollision(type);
-    if (type.startsWith('bumper'))  actuators.onBumperHit();
+    if (type.startsWith('bumper'))  { actuators.onBumperHit(); viewRuntime.shake(); }
     else if (type === 'slingshot') actuators.onSlingshotHit();
     else if (type === 'tunnel')    audio.play('milestone-2');
     else if (type === 'tunnel-rv') audio.play('milestone-1');
@@ -147,5 +147,5 @@ new GameLoop({
     level.launchGateActor.open();
   },
   gameState: network.gameState,
-  renderFn:  () => bloom.render(viewRuntime.getCamera()),
+  renderFn:  () => { viewRuntime.tickShake(); bloom.render(viewRuntime.getCamera()); },
 }).start();


### PR DESCRIPTION
…ections

  - losange: per-part materials (rust-metal base + construction-yellow top)
  - triangles: gunmetal + cyan theme; the left reuses the right GLB mirrored around the playable-center axis for true symmetry
  - barrels: keep upright (own rotation) + quarter-turn so the logo faces front
  - camera shake on every bumper hit (decaying, capped)
  - add environment map (reflections) + vignette for a richer render
  - brighten the scene (higher ambient + exposure) so the warm lights no longer darken the surface colors