### PR TITLE
feat(audio): prevent special event sound overlap; add demo video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Flipper virtuel multi-écran : **Playfield** (3D), **Backglass**, **DMD**, synch
 
 Documentation (index unique) : [`docs/README.md`](docs/README.md). Alignement sur le sujet officiel **HETIC Web3** (barème, IoT, livrables) : [`docs/hetic/referentiel-sujet-hetic-web3.md`](docs/hetic/referentiel-sujet-hetic-web3.md).
 
+## Demo
+
+[Vidéo de démonstration](https://drive.google.com/file/d/13VkodJtVlOaUTLCyD5YJKLMhbRPIjARD/view?usp=sharing)
+
 ## Arborescence des packages
 
 ```

--- a/playfield/src/adapters/audio/AudioEngine.js
+++ b/playfield/src/adapters/audio/AudioEngine.js
@@ -162,8 +162,11 @@ class AudioEngine {
     if (now - (this.#lastPlayed.get(key) || 0) < COOLDOWN_MS) return;
 
     const grp = this.#sampleToGroup.get(key);
-    const isHeavySound = grp === "Game Over" || grp === "Highscore beat";
-    if (isHeavySound && now < this.#soundLockEndTime) return;
+    const isHeavySound = grp === "Game Over" || grp === "Highscore beat" || grp === "Special events";
+    if (isHeavySound && now < this.#soundLockEndTime) {
+      if (grp === "Highscore beat") setTimeout(() => this.play(key), this.#soundLockEndTime - now);
+      return;
+    }
 
     this.#lastPlayed.set(key, now);
 


### PR DESCRIPTION
- Special events now use soundLock to prevent self-overlap and cross-overlap
- Highscore beat queues after special event sound finishes instead of being dropped
- Added demo video link in README